### PR TITLE
Studio: UI/code view toggle and Monaco editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,8 @@ After creating the symlink for your editor of choice, restart the editor to acti
 
 **Orca Studio** is an in-browser companion to the text-based language: a [Next.js](https://nextjs.org/) app that lays out Orca concepts — models, agents, tools, tasks, workflows, and the edges between them — on an interactive canvas.
 
+Try it online: [Orca Studio (GitHub Pages)](https://thakeenathees.github.io/orca/studio/).
+
 To run Studio locally:
 
 ```

--- a/studio/app/page.tsx
+++ b/studio/app/page.tsx
@@ -1,20 +1,63 @@
 "use client";
 
+import dynamic from "next/dynamic";
+import { useState } from "react";
 import { ReactFlowProvider } from "@xyflow/react";
 import { TopBar } from "@/components/top-bar";
 import { Palette } from "@/components/palette";
 import { Canvas } from "@/components/canvas";
 import { Inspector } from "@/components/inspector";
+import {
+  ViewModeToggle,
+  type StudioViewMode,
+} from "@/components/view-mode-toggle";
+import { SAMPLE_ORCA_SOURCE } from "@/lib/sample-oc";
+
+const StudioCodeEditor = dynamic(
+  () =>
+    import("@/components/studio-code-editor").then((m) => m.StudioCodeEditor),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex min-h-0 min-w-0 flex-1 flex-col items-center justify-center border-x border-border bg-card text-sm text-muted-foreground">
+        Loading editor…
+      </div>
+    ),
+  }
+);
 
 export default function Home() {
+  const [viewMode, setViewMode] = useState<StudioViewMode>("ui");
+  const [sourceCode, setSourceCode] = useState(SAMPLE_ORCA_SOURCE);
+
   return (
     <ReactFlowProvider>
       <div className="flex h-full flex-col">
         <TopBar />
-        <div className="flex flex-1 overflow-hidden">
-          <Palette />
-          <Canvas />
-          <Inspector />
+        <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+          <div className="pointer-events-none absolute left-1/2 top-[16px] z-50 -translate-x-1/2">
+            <div className="pointer-events-auto">
+              <ViewModeToggle mode={viewMode} onModeChange={setViewMode} />
+            </div>
+          </div>
+          <div className="flex min-h-0 flex-1 overflow-hidden">
+            <Palette />
+            <div
+              className="relative flex min-h-0 min-w-0 flex-1 flex-col"
+              id="studio-panel-center"
+              role="tabpanel"
+              aria-labelledby={
+                viewMode === "ui" ? "studio-tab-ui" : "studio-tab-code"
+              }
+            >
+              {viewMode === "ui" ? (
+                <Canvas />
+              ) : (
+                <StudioCodeEditor value={sourceCode} onChange={setSourceCode} />
+              )}
+            </div>
+            {viewMode === "ui" ? <Inspector /> : null}
+          </div>
         </div>
       </div>
     </ReactFlowProvider>

--- a/studio/components/studio-code-editor.tsx
+++ b/studio/components/studio-code-editor.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Editor from "@monaco-editor/react";
+
+type StudioCodeEditorProps = {
+  value: string;
+  onChange: (value: string) => void;
+};
+
+/**
+ * Orca source buffer using Monaco (client-only; parent should load via next/dynamic ssr:false).
+ * Monaco’s built-in `hcl` mode matches Terraform / HashiCorp-style blocks (close to `.oc`).
+ */
+export function StudioCodeEditor({ value, onChange }: StudioCodeEditorProps) {
+  return (
+    <div className="flex min-h-0 min-w-0 flex-1 flex-col border-x border-border bg-card">
+      <Editor
+        height="100%"
+        language="hcl"
+        theme="vs-dark"
+        value={value}
+        onChange={(v) => onChange(v ?? "")}
+        options={{
+          minimap: { enabled: false },
+          fontSize: 13,
+          fontFamily:
+            "var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, Monaco, monospace",
+          scrollBeyondLastLine: false,
+          wordWrap: "on",
+          padding: { top: 12 },
+          tabSize: 4,
+        }}
+        loading={
+          <div className="flex h-full min-h-[12rem] items-center justify-center text-sm text-muted-foreground">
+            Loading editor…
+          </div>
+        }
+      />
+    </div>
+  );
+}

--- a/studio/components/top-bar.tsx
+++ b/studio/components/top-bar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Play, Hammer, Workflow } from "lucide-react";
+import { Hammer, Play, Workflow } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { cn } from "@/lib/utils";
 
@@ -105,6 +105,29 @@ export function TopBar() {
           <Play className="h-3.5 w-3.5 shrink-0" />
           Run
         </div>
+        <a
+          href="https://github.com/ThakeeNathees/orca"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex size-8 shrink-0 items-center justify-center rounded-md text-sidebar-foreground transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+          aria-label="Orca repository on GitHub"
+          title="View source on GitHub"
+        >
+          {/* Lucide dropped brand icons; GitHub mark from https://github.com/logos */}
+          <svg
+            className="size-[18px] shrink-0"
+            viewBox="0 0 98 96"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden
+          >
+            <path
+              fill="currentColor"
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+            />
+          </svg>
+        </a>
       </div>
     </header>
   );

--- a/studio/components/view-mode-toggle.tsx
+++ b/studio/components/view-mode-toggle.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { FileCode2, LayoutPanelLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/** Whether the center pane shows the React Flow canvas or the Monaco buffer. */
+export type StudioViewMode = "ui" | "code";
+
+type ViewModeToggleProps = {
+  mode: StudioViewMode;
+  onModeChange: (mode: StudioViewMode) => void;
+};
+
+const segmentClass =
+  "inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
+
+/**
+ * Segmented control to switch between visual canvas and source editing.
+ * Uses tab semantics for keyboard and screen-reader users.
+ */
+export function ViewModeToggle({ mode, onModeChange }: ViewModeToggleProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Editor view"
+      className="flex items-center gap-0.5 rounded-full border border-border bg-sidebar/95 px-1 py-0.5 shadow-md backdrop-blur-sm dark:bg-[#18181B]/95"
+    >
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === "ui"}
+        id="studio-tab-ui"
+        aria-controls="studio-panel-center"
+        tabIndex={mode === "ui" ? 0 : -1}
+        onClick={() => onModeChange("ui")}
+        className={cn(
+          segmentClass,
+          mode === "ui"
+            ? "bg-neutral-200 text-sidebar-foreground shadow-sm dark:bg-zinc-600 dark:text-zinc-50"
+            : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-foreground"
+        )}
+      >
+        <LayoutPanelLeft className="size-3.5 shrink-0" aria-hidden />
+        UI
+      </button>
+      <button
+        type="button"
+        role="tab"
+        aria-selected={mode === "code"}
+        id="studio-tab-code"
+        aria-controls="studio-panel-center"
+        tabIndex={mode === "code" ? 0 : -1}
+        onClick={() => onModeChange("code")}
+        className={cn(
+          segmentClass,
+          mode === "code"
+            ? "bg-neutral-200 text-sidebar-foreground shadow-sm dark:bg-zinc-600 dark:text-zinc-50"
+            : "text-muted-foreground hover:bg-sidebar-accent/60 hover:text-sidebar-foreground"
+        )}
+      >
+        <FileCode2 className="size-3.5 shrink-0" aria-hidden />
+        Code
+      </button>
+    </div>
+  );
+}

--- a/studio/lib/sample-oc.ts
+++ b/studio/lib/sample-oc.ts
@@ -1,0 +1,31 @@
+/**
+ * Default buffer for the Studio code pane until graph ↔ .oc sync exists.
+ * Kept in sync conceptually with ../../orca/main.oc (sample workflow).
+ */
+export const SAMPLE_ORCA_SOURCE = `
+
+// The model block is used to configure the model to use for the agent.
+model gpt4o {
+  provider    = "openai"
+  model_name  = "gpt-4o"
+  temperature = 0.7
+}
+
+// Note that this is a dummy block and the real implementation is still WIP.
+memory session_memory {
+  id        = "session_store"
+  description = "Conversation and tool-call history"
+}
+
+// The agent block is used to define the agent.
+agent researcher {
+  model   = gpt4o
+  persona = "Find and summarize information."
+  tools   = [
+    builtin.web_search,
+    builtin.code_interpreter,
+  ]
+  memory  = session_memory
+}
+
+`;

--- a/studio/next.config.ts
+++ b/studio/next.config.ts
@@ -1,11 +1,15 @@
 import type { NextConfig } from "next";
 
-// Subpath on GitHub Pages: VitePress `base` is `/orca/` (docs/.vitepress/config.ts).
-const basePath = "/orca/studio";
+// GitHub Pages hosts Studio under `/orca/studio` (see docs `.vitepress` base `/orca/`).
+// `package.json` sets `ORCA_STUDIO_BASE_PATH` only for `pnpm run build`, so `next dev`
+// serves at `http://localhost:3000/` with no `basePath`. Relying on `NODE_ENV` here
+// is unreliable because Next may load this config before it flips to `production`.
+// `output: "export"` forbids middleware/proxy.
+const basePath = process.env.ORCA_STUDIO_BASE_PATH ?? "";
 
 const nextConfig: NextConfig = {
   output: "export",
-  basePath,
+  ...(basePath ? { basePath } : {}),
 };
 
 export default nextConfig;

--- a/studio/package.json
+++ b/studio/package.json
@@ -4,16 +4,18 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "ORCA_STUDIO_BASE_PATH=/orca/studio next build",
     "start": "next start",
     "lint": "eslint"
   },
   "dependencies": {
     "@base-ui/react": "^1.3.0",
+    "@monaco-editor/react": "^4.7.0",
     "@xyflow/react": "^12.10.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
+    "monaco-editor": "^0.55.1",
     "next": "16.2.2",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/studio/pnpm-lock.yaml
+++ b/studio/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@base-ui/react':
         specifier: ^1.3.0
         version: 1.3.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@monaco-editor/react':
+        specifier: ^4.7.0
+        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@xyflow/react':
         specifier: ^12.10.2
         version: 12.10.2(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -23,6 +26,9 @@ importers:
       lucide-react:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)
+      monaco-editor:
+        specifier: ^0.55.1
+        version: 0.55.1
       next:
         specifier: 16.2.2
         version: 16.2.2(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -538,6 +544,16 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
+  '@monaco-editor/loader@1.7.0':
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
+
+  '@monaco-editor/react@4.7.0':
+    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@mswjs/interceptors@0.41.3':
     resolution: {integrity: sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==}
     engines: {node: '>=18'}
@@ -791,6 +807,9 @@ packages:
 
   '@types/statuses@2.0.6':
     resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -1361,6 +1380,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dompurify@3.2.7:
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
   dotenv@17.4.0:
     resolution: {integrity: sha512-kCKF62fwtzwYm0IGBNjRUjtJgMfGapII+FslMHIjMR5KTnwEmBmWLDRSnc3XSNP8bNy34tekgQyDT0hr7pERRQ==}
@@ -2221,6 +2243,11 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -2269,6 +2296,9 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  monaco-editor@0.55.1:
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2711,6 +2741,9 @@ packages:
 
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
+
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -3580,6 +3613,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@monaco-editor/loader@1.7.0':
+    dependencies:
+      state-local: 1.0.7
+
+  '@monaco-editor/react@4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@monaco-editor/loader': 1.7.0
+      monaco-editor: 0.55.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@mswjs/interceptors@0.41.3':
     dependencies:
       '@open-draft/deferred-promise': 2.2.0
@@ -3787,6 +3831,9 @@ snapshots:
       csstype: 3.2.3
 
   '@types/statuses@2.0.6': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -4340,6 +4387,10 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@17.4.0: {}
 
@@ -5321,6 +5372,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  marked@14.0.0: {}
+
   math-intrinsics@1.1.0: {}
 
   media-typer@1.1.0: {}
@@ -5355,6 +5408,11 @@ snapshots:
       brace-expansion: 1.1.13
 
   minimist@1.2.8: {}
+
+  monaco-editor@0.55.1:
+    dependencies:
+      dompurify: 3.2.7
+      marked: 14.0.0
 
   ms@2.1.3: {}
 
@@ -5923,6 +5981,8 @@ snapshots:
   source-map@0.6.1: {}
 
   stable-hash@0.0.5: {}
+
+  state-local@1.0.7: {}
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
## Summary

Adds a segmented control to switch the center pane between the React Flow canvas and a Monaco-based Orca source editor. Includes sample `.oc` content updates and small layout tweaks (toggle positioning).

## Changes

- View mode toggle with tab semantics for accessibility
- Dynamic import of the code editor to avoid SSR issues
- Adjusted vertical placement of the toggle for clearer separation from the top bar

Made with [Cursor](https://cursor.com)