### PR TITLE
Fix flaky codegen: deterministic tool import order

### DIFF
--- a/compiler/codegen/langgraph/tool.go
+++ b/compiler/codegen/langgraph/tool.go
@@ -164,12 +164,17 @@ func toolBlockSource(tool *ast.BlockStatement, invokeRef string) string {
 }
 
 // toolImports returns the collected Python imports from dotted-path tool invokes.
+// Order matches top-level tool block order in the source file (not map iteration,
+// which is randomized and would make golden tests flaky).
 func (b *LangGraphBackend) toolImports() []python.PythonImport {
+	tools := b.CollectBlocksByKind(token.BlockTool)
 	var imports []python.PythonImport
-	for _, resolved := range b.resolvedTools {
-		if resolved.pyImport != nil {
-			imports = append(imports, *resolved.pyImport)
+	for _, tool := range tools {
+		resolved, ok := b.resolvedTools[tool.Name]
+		if !ok || resolved.pyImport == nil {
+			continue
 		}
+		imports = append(imports, *resolved.pyImport)
 	}
 	return imports
 }


### PR DESCRIPTION
CI on `main` failed after merging cron/webhook work because `go test` hit a golden mismatch on `agent_with_tools`: `toolImports()` iterated `resolvedTools` (a map), so Python `from ... import` lines for tools appeared in nondeterministic order.

This change collects imports by walking tool blocks in **source order**, matching `writeToolSection` and keeping golden output stable.

**Local coverage** (same as workflow: `cd compiler && go test -coverprofile=coverage.out ./...`):

- **total: 75.6%** (`go tool cover -func=coverage.out | grep '^total:'`)

The failing run was not the 10% coverage *threshold* step (that only runs on pull requests); the job failed at `go test` because the codegen package tests did not complete successfully.

Made with [Cursor](https://cursor.com)