### PR TITLE
Add studio dashboard with project sidebar

### DIFF
--- a/studio/app/page.tsx
+++ b/studio/app/page.tsx
@@ -7,11 +7,14 @@ import { TopBar } from "@/components/top-bar";
 import { Palette } from "@/components/palette";
 import { Canvas } from "@/components/canvas";
 import { Inspector } from "@/components/inspector";
+import { NavSidebar } from "@/components/nav-sidebar";
+import { Dashboard } from "@/components/dashboard";
 import {
   ViewModeToggle,
   type StudioViewMode,
 } from "@/components/view-mode-toggle";
 import { SAMPLE_ORCA_SOURCE } from "@/lib/sample-oc";
+import { useStudioStore } from "@/lib/store";
 
 const StudioCodeEditor = dynamic(
   () =>
@@ -26,38 +29,51 @@ const StudioCodeEditor = dynamic(
   }
 );
 
-export default function Home() {
+function WorkflowEditor() {
   const [viewMode, setViewMode] = useState<StudioViewMode>("ui");
   const [sourceCode, setSourceCode] = useState(SAMPLE_ORCA_SOURCE);
 
   return (
+    <div className="flex h-full flex-col">
+      <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="pointer-events-none absolute left-1/2 top-[16px] z-50 -translate-x-1/2">
+          <div className="pointer-events-auto">
+            <ViewModeToggle mode={viewMode} onModeChange={setViewMode} />
+          </div>
+        </div>
+        <div className="flex min-h-0 flex-1 overflow-hidden">
+          <Palette />
+          <div
+            className="relative flex min-h-0 min-w-0 flex-1 flex-col"
+            id="studio-panel-center"
+            role="tabpanel"
+            aria-labelledby={
+              viewMode === "ui" ? "studio-tab-ui" : "studio-tab-code"
+            }
+          >
+            {viewMode === "ui" ? (
+              <Canvas />
+            ) : (
+              <StudioCodeEditor value={sourceCode} onChange={setSourceCode} />
+            )}
+          </div>
+          {viewMode === "ui" ? <Inspector /> : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function Home() {
+  const currentView = useStudioStore((s) => s.currentView);
+
+  return (
     <ReactFlowProvider>
-      <div className="flex h-full flex-col">
-        <TopBar />
-        <div className="relative flex min-h-0 flex-1 flex-col overflow-hidden">
-          <div className="pointer-events-none absolute left-1/2 top-[16px] z-50 -translate-x-1/2">
-            <div className="pointer-events-auto">
-              <ViewModeToggle mode={viewMode} onModeChange={setViewMode} />
-            </div>
-          </div>
-          <div className="flex min-h-0 flex-1 overflow-hidden">
-            <Palette />
-            <div
-              className="relative flex min-h-0 min-w-0 flex-1 flex-col"
-              id="studio-panel-center"
-              role="tabpanel"
-              aria-labelledby={
-                viewMode === "ui" ? "studio-tab-ui" : "studio-tab-code"
-              }
-            >
-              {viewMode === "ui" ? (
-                <Canvas />
-              ) : (
-                <StudioCodeEditor value={sourceCode} onChange={setSourceCode} />
-              )}
-            </div>
-            {viewMode === "ui" ? <Inspector /> : null}
-          </div>
+      <div className="flex h-full">
+        <NavSidebar />
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
+          <TopBar />
+          {currentView === "dashboard" ? <Dashboard /> : <WorkflowEditor />}
         </div>
       </div>
     </ReactFlowProvider>

--- a/studio/app/page.tsx
+++ b/studio/app/page.tsx
@@ -8,6 +8,7 @@ import { Palette } from "@/components/palette";
 import { Canvas } from "@/components/canvas";
 import { Inspector } from "@/components/inspector";
 import { NavSidebar } from "@/components/nav-sidebar";
+import { ProjectSidebar } from "@/components/project-sidebar";
 import { Dashboard } from "@/components/dashboard";
 import {
   ViewModeToggle,
@@ -71,6 +72,7 @@ export default function Home() {
     <ReactFlowProvider>
       <div className="flex h-full">
         <NavSidebar />
+        {currentView === "dashboard" && <ProjectSidebar />}
         <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           <TopBar />
           {currentView === "dashboard" ? <Dashboard /> : <WorkflowEditor />}

--- a/studio/components/dashboard.tsx
+++ b/studio/components/dashboard.tsx
@@ -93,9 +93,12 @@ function WorkflowMenu({
 }
 
 export function Dashboard() {
-  const workflows = useStudioStore((s) => s.workflows);
+  const allWorkflows = useStudioStore((s) => s.workflows);
+  const activeProjectId = useStudioStore((s) => s.activeProjectId);
   const openWorkflow = useStudioStore((s) => s.openWorkflow);
   const deleteWorkflow = useStudioStore((s) => s.deleteWorkflow);
+
+  const workflows = allWorkflows.filter((w) => w.projectId === activeProjectId);
 
   const [deleteTarget, setDeleteTarget] = useState<WorkflowSummary | null>(
     null

--- a/studio/components/dashboard.tsx
+++ b/studio/components/dashboard.tsx
@@ -1,0 +1,205 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Workflow, MoreHorizontal, FolderOpen, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Dialog, DialogHeader, DialogBody } from "@/components/ui/dialog";
+import { useStudioStore } from "@/lib/store";
+import type { WorkflowSummary } from "@/lib/types";
+
+/** Format a Date as a relative time string (e.g. "Edited 2 minutes ago"). */
+function timeAgo(date: Date): string {
+  const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
+  if (seconds < 60) return "Edited just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60)
+    return `Edited ${minutes} minute${minutes !== 1 ? "s" : ""} ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `Edited ${hours} hour${hours !== 1 ? "s" : ""} ago`;
+  const days = Math.floor(hours / 24);
+  return `Edited ${days} day${days !== 1 ? "s" : ""} ago`;
+}
+
+/** Dropdown menu anchored to the three-dot button. */
+function WorkflowMenu({
+  workflow,
+  onOpen,
+  onDelete,
+}: {
+  workflow: WorkflowSummary;
+  onOpen: () => void;
+  onDelete: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  return (
+    <div ref={menuRef} className="relative shrink-0">
+      <button
+        type="button"
+        className="flex size-8 items-center justify-center rounded-md text-muted-foreground opacity-100 hover:bg-accent hover:text-foreground cursor-pointer"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((prev) => !prev);
+        }}
+        aria-label={`Options for ${workflow.name}`}
+      >
+        <MoreHorizontal className="size-4" />
+      </button>
+
+      {open && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-40 overflow-hidden rounded-md border border-border bg-card shadow-lg">
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 px-3 py-2 text-sm text-foreground transition-colors hover:bg-accent cursor-pointer"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onOpen();
+            }}
+          >
+            <FolderOpen className="size-4" />
+            Open
+          </button>
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 px-3 py-2 text-sm text-[#ef4444] transition-colors hover:bg-accent cursor-pointer"
+            onClick={(e) => {
+              e.stopPropagation();
+              setOpen(false);
+              onDelete();
+            }}
+          >
+            <Trash2 className="size-4" />
+            Delete
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function Dashboard() {
+  const workflows = useStudioStore((s) => s.workflows);
+  const openWorkflow = useStudioStore((s) => s.openWorkflow);
+  const deleteWorkflow = useStudioStore((s) => s.deleteWorkflow);
+
+  const [deleteTarget, setDeleteTarget] = useState<WorkflowSummary | null>(
+    null
+  );
+
+  const confirmDelete = useCallback(() => {
+    if (deleteTarget) {
+      deleteWorkflow(deleteTarget.id);
+      setDeleteTarget(null);
+    }
+  }, [deleteTarget, deleteWorkflow]);
+
+  return (
+    <div className="flex h-full flex-1 flex-col bg-sidebar">
+      {/* Workflow list */}
+      <ScrollArea className="flex-1">
+        <div className="px-8 py-4">
+          {workflows.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-20 text-muted-foreground">
+              <Workflow className="size-10 mb-3 opacity-40" />
+              <p className="text-sm">No workflows yet</p>
+              <p className="text-xs mt-1">
+                Click &quot;+ New Workflow&quot; to get started
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-1">
+              {workflows.map((wf) => (
+                <div
+                  key={wf.id}
+                  role="button"
+                  tabIndex={0}
+                  onClick={() => openWorkflow(wf.id)}
+                  onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") openWorkflow(wf.id); }}
+                  className="group flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left transition-colors hover:bg-[#27272A] cursor-pointer"
+                >
+                  {/* Icon */}
+                  <div
+                    className="flex size-10 shrink-0 items-center justify-center rounded-lg shadow-sm"
+                    style={{ backgroundColor: wf.color }}
+                  >
+                    <Workflow className="size-[18px] text-[#18181b]" />
+                  </div>
+
+                  {/* Name + timestamp */}
+                  <div className="min-w-0 flex-1">
+                    <span className="block truncate text-sm font-medium text-foreground">
+                      {wf.name}
+                    </span>
+                    <span className="block text-xs text-muted-foreground">
+                      {timeAgo(wf.updatedAt)}
+                    </span>
+                  </div>
+
+                  {/* Three-dot menu */}
+                  <WorkflowMenu
+                    workflow={wf}
+                    onOpen={() => openWorkflow(wf.id)}
+                    onDelete={() => setDeleteTarget(wf)}
+                  />
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+
+      {/* Delete confirmation dialog */}
+      <Dialog
+        open={deleteTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setDeleteTarget(null);
+        }}
+      >
+        <DialogHeader onClose={() => setDeleteTarget(null)}>
+          Delete Workflow
+        </DialogHeader>
+        <DialogBody className="px-4 py-4">
+          <p className="text-sm text-muted-foreground">
+            Are you sure you want to delete{" "}
+            <span className="font-medium text-foreground">
+              {deleteTarget?.name}
+            </span>
+            ? This action cannot be undone.
+          </p>
+          <div className="mt-4 flex justify-end gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setDeleteTarget(null)}
+              className="cursor-pointer"
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={confirmDelete}
+              className="bg-[#ef4444] text-white hover:bg-[#dc2626] cursor-pointer"
+            >
+              Delete
+            </Button>
+          </div>
+        </DialogBody>
+      </Dialog>
+    </div>
+  );
+}

--- a/studio/components/nav-sidebar.tsx
+++ b/studio/components/nav-sidebar.tsx
@@ -38,7 +38,7 @@ export function NavSidebar() {
                 className={cn(
                   "flex size-9 items-center justify-center rounded-md transition-colors",
                   isActive
-                    ? "bg-accent text-foreground"
+                    ? "bg-[#27272A] text-foreground"
                     : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
                   btnProps.className
                 )}

--- a/studio/components/nav-sidebar.tsx
+++ b/studio/components/nav-sidebar.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { GitBranch } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { useStudioStore } from "@/lib/store";
+
+export function NavSidebar() {
+  const currentView = useStudioStore((s) => s.currentView);
+  const goToDashboard = useStudioStore((s) => s.goToDashboard);
+
+  const isActive = currentView === "dashboard";
+
+  return (
+    <aside className="flex w-[52px] shrink-0 flex-col items-center border-r border-border bg-sidebar py-3 gap-4">
+      {/* Workflows nav item */}
+      <Tooltip>
+        <TooltipTrigger
+          render={(props) => {
+            const p = { ...props } as Record<string, unknown>;
+            delete p.type;
+            const btnProps =
+              p as React.ButtonHTMLAttributes<HTMLButtonElement>;
+            return (
+              <button
+                type="button"
+                {...btnProps}
+                onClick={(e) => {
+                  btnProps.onClick?.(
+                    e as React.MouseEvent<HTMLButtonElement>
+                  );
+                  goToDashboard();
+                }}
+                className={cn(
+                  "flex size-9 items-center justify-center rounded-md transition-colors",
+                  isActive
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:bg-accent/50 hover:text-foreground",
+                  btnProps.className
+                )}
+                aria-label="Workflows"
+              >
+                <GitBranch className="size-[18px]" />
+              </button>
+            );
+          }}
+        />
+        <TooltipContent side="right" sideOffset={8}>
+          Workflows
+        </TooltipContent>
+      </Tooltip>
+    </aside>
+  );
+}

--- a/studio/components/project-sidebar.tsx
+++ b/studio/components/project-sidebar.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Plus, MoreHorizontal } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { useStudioStore } from "@/lib/store";
+
+function ProjectItem({
+  project,
+  isActive,
+  onSelect,
+  onRename,
+  onDelete,
+}: {
+  project: { id: string; name: string };
+  isActive: boolean;
+  onSelect: () => void;
+  onRename: (name: string) => void;
+  onDelete: () => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [menuPos, setMenuPos] = useState({ top: 0, left: 0 });
+  const [editValue, setEditValue] = useState(project.name);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+  const menuBtnRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setMenuOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [menuOpen]);
+
+  const commitRename = () => {
+    const trimmed = editValue.trim();
+    if (trimmed && trimmed !== project.name) {
+      onRename(trimmed);
+    } else {
+      setEditValue(project.name);
+    }
+    setEditing(false);
+  };
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={() => {
+        if (!editing) onSelect();
+      }}
+      onDoubleClick={() => {
+        setEditing(true);
+        setEditValue(project.name);
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") onSelect();
+      }}
+      className={cn(
+        "group flex w-full items-center justify-between rounded-md px-3 py-2 text-sm transition-colors cursor-pointer",
+        isActive
+          ? "bg-[#27272A] text-foreground"
+          : "text-muted-foreground hover:bg-accent/50 hover:text-foreground"
+      )}
+    >
+      {editing ? (
+        <input
+          ref={inputRef}
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={commitRename}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") commitRename();
+            if (e.key === "Escape") {
+              setEditValue(project.name);
+              setEditing(false);
+            }
+            e.stopPropagation();
+          }}
+          onClick={(e) => e.stopPropagation()}
+          className="min-w-0 flex-1 rounded border border-border bg-background px-1.5 py-0.5 text-sm text-foreground outline-none focus:ring-1 focus:ring-ring"
+        />
+      ) : (
+        <span className="min-w-0 flex-1 truncate">{project.name}</span>
+      )}
+
+      {/* Three-dot menu */}
+      {!editing && (
+        <div ref={menuRef} className="relative shrink-0">
+          <button
+            ref={menuBtnRef}
+            type="button"
+            className="ml-1 flex size-6 items-center justify-center rounded text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100 hover:bg-accent hover:text-foreground cursor-pointer"
+            onClick={(e) => {
+              e.stopPropagation();
+              if (!menuOpen && menuBtnRef.current) {
+                const rect = menuBtnRef.current.getBoundingClientRect();
+                setMenuPos({ top: rect.bottom + 4, left: rect.left });
+              }
+              setMenuOpen((prev) => !prev);
+            }}
+            aria-label={`Options for ${project.name}`}
+          >
+            <MoreHorizontal className="size-3.5" />
+          </button>
+
+          {menuOpen && (
+            <div
+              className="fixed z-[9999] w-32 overflow-hidden rounded-md border border-border bg-card shadow-lg"
+              style={{ top: menuPos.top, left: menuPos.left }}
+            >
+              <button
+                type="button"
+                className="flex w-full items-center px-3 py-2 text-sm text-foreground transition-colors hover:bg-accent cursor-pointer"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setMenuOpen(false);
+                  setEditing(true);
+                  setEditValue(project.name);
+                }}
+              >
+                Rename
+              </button>
+              <button
+                type="button"
+                className="flex w-full items-center px-3 py-2 text-sm text-red-400 transition-colors hover:bg-accent cursor-pointer"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setMenuOpen(false);
+                  onDelete();
+                }}
+              >
+                Delete
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ProjectSidebar() {
+  const projects = useStudioStore((s) => s.projects);
+  const activeProjectId = useStudioStore((s) => s.activeProjectId);
+  const createProject = useStudioStore((s) => s.createProject);
+  const renameProject = useStudioStore((s) => s.renameProject);
+  const deleteProject = useStudioStore((s) => s.deleteProject);
+  const setActiveProject = useStudioStore((s) => s.setActiveProject);
+
+  return (
+    <aside className="flex w-[220px] shrink-0 flex-col border-r border-border bg-sidebar">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-3">
+        <span className="text-sm font-semibold text-foreground">Projects</span>
+        <button
+          type="button"
+          onClick={createProject}
+          className="flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground cursor-pointer"
+          aria-label="New project"
+        >
+          <Plus className="size-4" />
+        </button>
+      </div>
+
+      {/* Project list */}
+      <div className="flex-1 space-y-0.5 overflow-y-auto px-2">
+        {projects.map((project) => (
+          <ProjectItem
+            key={project.id}
+            project={project}
+            isActive={project.id === activeProjectId}
+            onSelect={() => setActiveProject(project.id)}
+            onRename={(name) => renameProject(project.id, name)}
+            onDelete={() => deleteProject(project.id)}
+          />
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/studio/components/top-bar.tsx
+++ b/studio/components/top-bar.tsx
@@ -1,17 +1,35 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Hammer, Play, Workflow } from "lucide-react";
+import { ArrowLeft, Hammer, Play, Plus, Workflow } from "lucide-react";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { useStudioStore } from "@/lib/store";
 
 const DEFAULT_WORKFLOW_NAME = "My Workflow";
 
 export function TopBar() {
-  const [workflowName, setWorkflowName] = useState(DEFAULT_WORKFLOW_NAME);
-  const [draft, setDraft] = useState(DEFAULT_WORKFLOW_NAME);
+  const currentView = useStudioStore((s) => s.currentView);
+  const goToDashboard = useStudioStore((s) => s.goToDashboard);
+  const createWorkflow = useStudioStore((s) => s.createWorkflow);
+  const activeWorkflowId = useStudioStore((s) => s.activeWorkflowId);
+  const workflows = useStudioStore((s) => s.workflows);
+  const isEditor = currentView === "editor";
+
+  const activeWorkflow = workflows.find((w) => w.id === activeWorkflowId);
+  const initialName = activeWorkflow?.name ?? DEFAULT_WORKFLOW_NAME;
+
+  const [workflowName, setWorkflowName] = useState(initialName);
+  const [draft, setDraft] = useState(initialName);
   const [editing, setEditing] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  // Sync when switching workflows
+  useEffect(() => {
+    setWorkflowName(initialName);
+    setDraft(initialName);
+  }, [initialName]);
 
   const commit = useCallback(() => {
     const t = draft.trim();
@@ -36,98 +54,123 @@ export function TopBar() {
 
   return (
     <header className="flex h-12 shrink-0 items-center border-b border-border bg-sidebar px-4 text-sidebar-foreground">
-      <div className="flex min-w-0 flex-1 items-center">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        {isEditor && (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={goToDashboard}
+            className="shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
+            aria-label="Back to workflows"
+          >
+            <ArrowLeft className="size-4" />
+          </Button>
+        )}
         <span className="text-base font-semibold tracking-tight">
-          Orca Studio
+          {isEditor ? "Orca Studio" : "Workflows"}
         </span>
       </div>
 
-      <div className="flex shrink-0 items-center gap-2">
-        <div
-          className="flex size-8 shrink-0 items-center justify-center rounded-md bg-[#86efac] shadow-sm dark:bg-[#6ee7b7]"
-          aria-hidden
-        >
-          <Workflow
-            className="size-[15px] text-[#18181b] dark:text-[#0f172a]"
-            strokeWidth={2}
-          />
-        </div>
-        {editing ? (
-          <Input
-            ref={inputRef}
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            onBlur={commit}
-            onKeyDown={(e) => {
-              if (e.key === "Enter") {
-                e.preventDefault();
-                commit();
-              }
-              if (e.key === "Escape") {
-                e.preventDefault();
-                cancel();
-              }
-            }}
-            className={cn(
-              "h-8 min-w-[10rem] max-w-[min(24rem,calc(100vw-12rem))] border-border bg-sidebar-accent px-2.5 text-base font-semibold text-sidebar-foreground",
-              "focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40"
-            )}
-            aria-label="Workflow name"
-            maxLength={120}
-          />
-        ) : (
-          <button
-            type="button"
-            onClick={() => {
-              setDraft(workflowName);
-              setEditing(true);
-            }}
-            className="max-w-[min(24rem,calc(100vw-12rem))] truncate rounded-md px-1.5 py-0.5 text-left text-base font-semibold tracking-tight text-sidebar-foreground transition-colors hover:bg-sidebar-accent focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-            title="Click to rename"
-          >
-            {workflowName}
-          </button>
-        )}
-      </div>
-
-      <div className="flex min-w-0 flex-1 items-center justify-end gap-1">
-        <div
-          className="flex cursor-default items-center gap-1.5 rounded-md px-3 py-1.5 text-sm text-sidebar-foreground"
-          title="Coming soon"
-        >
-          <Hammer className="h-3.5 w-3.5 shrink-0" />
-          Build
-        </div>
-        <div
-          className="flex cursor-default items-center gap-1.5 rounded-md px-3 py-1.5 text-sm text-sidebar-foreground"
-          title="Coming soon"
-        >
-          <Play className="h-3.5 w-3.5 shrink-0" />
-          Run
-        </div>
-        <a
-          href="https://github.com/ThakeeNathees/orca"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="flex size-8 shrink-0 items-center justify-center rounded-md text-sidebar-foreground transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
-          aria-label="Orca repository on GitHub"
-          title="View source on GitHub"
-        >
-          {/* Lucide dropped brand icons; GitHub mark from https://github.com/logos */}
-          <svg
-            className="size-[18px] shrink-0"
-            viewBox="0 0 98 96"
-            xmlns="http://www.w3.org/2000/svg"
+      {isEditor && (
+        <div className="flex shrink-0 items-center gap-2">
+          <div
+            className="flex size-8 shrink-0 items-center justify-center rounded-md bg-[#86efac] shadow-sm dark:bg-[#6ee7b7]"
             aria-hidden
           >
-            <path
-              fill="currentColor"
-              fillRule="evenodd"
-              clipRule="evenodd"
-              d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+            <Workflow
+              className="size-[15px] text-[#18181b] dark:text-[#0f172a]"
+              strokeWidth={2}
             />
-          </svg>
-        </a>
+          </div>
+          {editing ? (
+            <Input
+              ref={inputRef}
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onBlur={commit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  commit();
+                }
+                if (e.key === "Escape") {
+                  e.preventDefault();
+                  cancel();
+                }
+              }}
+              className={cn(
+                "h-8 min-w-[10rem] max-w-[min(24rem,calc(100vw-12rem))] border-border bg-sidebar-accent px-2.5 text-base font-semibold text-sidebar-foreground",
+                "focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/40"
+              )}
+              aria-label="Workflow name"
+              maxLength={120}
+            />
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                setDraft(workflowName);
+                setEditing(true);
+              }}
+              className="max-w-[min(24rem,calc(100vw-12rem))] truncate rounded-md px-1.5 py-0.5 text-left text-base font-semibold tracking-tight text-sidebar-foreground transition-colors hover:bg-sidebar-accent focus-visible:border-ring focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              title="Click to rename"
+            >
+              {workflowName}
+            </button>
+          )}
+        </div>
+      )}
+
+      <div className="flex min-w-0 flex-1 items-center justify-end gap-1">
+        {isEditor ? (
+          <>
+            <div
+              className="flex cursor-default items-center gap-1.5 rounded-md px-3 py-1.5 text-sm text-sidebar-foreground"
+              title="Coming soon"
+            >
+              <Hammer className="h-3.5 w-3.5 shrink-0" />
+              Build
+            </div>
+            <div
+              className="flex cursor-default items-center gap-1.5 rounded-md px-3 py-1.5 text-sm text-sidebar-foreground"
+              title="Coming soon"
+            >
+              <Play className="h-3.5 w-3.5 shrink-0" />
+              Run
+            </div>
+            <a
+              href="https://github.com/ThakeeNathees/orca"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex size-8 shrink-0 items-center justify-center rounded-md text-sidebar-foreground transition-colors hover:bg-sidebar-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40"
+              aria-label="Orca repository on GitHub"
+              title="View source on GitHub"
+            >
+              <svg
+                className="size-[18px] shrink-0"
+                viewBox="0 0 98 96"
+                xmlns="http://www.w3.org/2000/svg"
+                aria-hidden
+              >
+                <path
+                  fill="currentColor"
+                  fillRule="evenodd"
+                  clipRule="evenodd"
+                  d="M48.854 0C21.839 0 0 22 0 49.217c0 21.756 13.993 40.172 33.405 46.69 2.427.49 3.316-1.059 3.316-2.362 0-1.141-.08-5.052-.08-9.127-13.59 2.934-16.42-5.867-16.42-5.867-2.184-5.704-5.42-7.17-5.42-7.17-4.448-3.015.324-3.015.324-3.015 4.934.326 7.523 5.052 7.523 5.052 4.367 7.496 11.404 5.378 14.235 4.074.404-3.178 1.699-5.378 3.074-6.6-10.839-1.141-22.243-5.378-22.243-24.283 0-5.378 1.94-9.778 5.014-13.2-.485-1.222-2.184-6.275.486-13.038 0 0 4.125-1.304 13.426 5.052a46.97 46.97 0 0 1 12.214-1.63c4.125 0 8.33.571 12.213 1.63 9.302-6.356 13.427-5.052 13.427-5.052 2.67 6.763.97 11.816.485 13.038 3.155 3.422 5.015 7.822 5.015 13.2 0 18.905-11.404 23.06-22.324 24.283 1.78 1.548 3.316 4.481 3.316 9.126 0 6.6-.08 11.897-.08 13.526 0 1.304.89 2.853 3.316 2.364 19.412-6.52 33.405-24.935 33.405-46.691C97.707 22 75.788 0 48.854 0z"
+                />
+              </svg>
+            </a>
+          </>
+        ) : (
+          <Button
+            onClick={createWorkflow}
+            size="sm"
+            className="gap-1.5 cursor-pointer"
+          >
+            <Plus className="size-4" />
+            New Workflow
+          </Button>
+        )}
       </div>
     </header>
   );

--- a/studio/lib/store.ts
+++ b/studio/lib/store.ts
@@ -12,6 +12,7 @@ import type {
   BlockKind,
   BlockNodeData,
   WorkflowSummary,
+  Project,
 } from "./types";
 import { BLOCK_DEFS } from "./block-defs";
 import { getEdgeAccentColor } from "./handle-colors";
@@ -23,6 +24,14 @@ interface StudioState {
   currentView: StudioView;
   workflows: WorkflowSummary[];
   activeWorkflowId: string | null;
+
+  /* ── Projects ── */
+  projects: Project[];
+  activeProjectId: string;
+  createProject: () => void;
+  renameProject: (id: string, name: string) => void;
+  deleteProject: (id: string) => void;
+  setActiveProject: (id: string) => void;
 
   createWorkflow: () => void;
   openWorkflow: (id: string) => void;
@@ -62,6 +71,16 @@ let workflowIdCounter = 2;
 function nextWorkflowId(): string {
   return `wf-${++workflowIdCounter}`;
 }
+
+let projectIdCounter = 1;
+function nextProjectId(): string {
+  return `proj-${++projectIdCounter}`;
+}
+
+const SEED_PROJECTS: Project[] = [
+  { id: "proj-1", name: "My Project" },
+];
+
 
 /** Nodes are 240px wide. Layout: lone agent centered above a row of model → memory → tools. */
 const NODE_W = 240;
@@ -204,12 +223,14 @@ const SEED_WORKFLOWS: WorkflowSummary[] = [
     name: "Vector Store RAG",
     updatedAt: new Date(Date.now() - 2 * 60 * 1000),
     color: "#f9a8d4",
+    projectId: "proj-1",
   },
   {
     id: "wf-2",
     name: "Basic Prompting",
     updatedAt: new Date(Date.now() - 3 * 60 * 1000),
     color: "#a78bfa",
+    projectId: "proj-1",
   },
 ];
 
@@ -219,6 +240,41 @@ export const useStudioStore = create<StudioState>((set, get) => ({
   workflows: SEED_WORKFLOWS,
   activeWorkflowId: null,
 
+  /* ── Projects ── */
+  projects: SEED_PROJECTS,
+  activeProjectId: "proj-1",
+
+  createProject: () => {
+    const id = nextProjectId();
+    set({
+      projects: [...get().projects, { id, name: "New Project" }],
+      activeProjectId: id,
+    });
+  },
+
+  renameProject: (id, name) => {
+    set({
+      projects: get().projects.map((p) =>
+        p.id === id ? { ...p, name } : p
+      ),
+    });
+  },
+
+  deleteProject: (id) => {
+    const projects = get().projects.filter((p) => p.id !== id);
+    if (projects.length === 0) return; // don't delete the last project
+    set({
+      projects,
+      workflows: get().workflows.filter((w) => w.projectId !== id),
+      activeProjectId:
+        get().activeProjectId === id ? projects[0].id : get().activeProjectId,
+    });
+  },
+
+  setActiveProject: (id) => {
+    set({ activeProjectId: id });
+  },
+
   createWorkflow: () => {
     const id = nextWorkflowId();
     const wf: WorkflowSummary = {
@@ -226,6 +282,7 @@ export const useStudioStore = create<StudioState>((set, get) => ({
       name: "Untitled Workflow",
       updatedAt: new Date(),
       color: randomPastelColor(),
+      projectId: get().activeProjectId,
     };
     set({
       workflows: [wf, ...get().workflows],

--- a/studio/lib/store.ts
+++ b/studio/lib/store.ts
@@ -6,11 +6,30 @@ import {
   type OnEdgesChange,
   type Connection,
 } from "@xyflow/react";
-import type { BlockNode, BlockEdge, BlockKind, BlockNodeData } from "./types";
+import type {
+  BlockNode,
+  BlockEdge,
+  BlockKind,
+  BlockNodeData,
+  WorkflowSummary,
+} from "./types";
 import { BLOCK_DEFS } from "./block-defs";
 import { getEdgeAccentColor } from "./handle-colors";
 
+type StudioView = "dashboard" | "editor";
+
 interface StudioState {
+  /* ── Navigation ── */
+  currentView: StudioView;
+  workflows: WorkflowSummary[];
+  activeWorkflowId: string | null;
+
+  createWorkflow: () => void;
+  openWorkflow: (id: string) => void;
+  deleteWorkflow: (id: string) => void;
+  goToDashboard: () => void;
+
+  /* ── Editor (per-workflow) ── */
   nodes: BlockNode[];
   edges: BlockEdge[];
   selectedNodeId: string | null;
@@ -21,7 +40,10 @@ interface StudioState {
 
   addNode: (kind: BlockKind, position: { x: number; y: number }) => void;
   removeNode: (id: string) => void;
-  updateNodeData: (id: string, fields: Partial<BlockNodeData["fields"]>) => void;
+  updateNodeData: (
+    id: string,
+    fields: Partial<BlockNodeData["fields"]>
+  ) => void;
   updateNodeLabel: (id: string, label: string) => void;
   setSelectedNodeId: (id: string | null) => void;
 }
@@ -34,6 +56,11 @@ function nextNodeId(): string {
 let edgeIdCounter = 0;
 function nextEdgeId(): string {
   return `edge-${++edgeIdCounter}`;
+}
+
+let workflowIdCounter = 2;
+function nextWorkflowId(): string {
+  return `wf-${++workflowIdCounter}`;
 }
 
 /** Nodes are 240px wide. Layout: lone agent centered above a row of model → memory → tools. */
@@ -153,7 +180,90 @@ const SAMPLE_EDGES: BlockEdge[] = [
   ),
 ];
 
+const PASTEL_COLORS = [
+  "#f9a8d4", // pink
+  "#a78bfa", // purple
+  "#93c5fd", // blue
+  "#6ee7b7", // green
+  "#fcd34d", // yellow
+  "#fdba74", // orange
+  "#f87171", // red
+  "#67e8f9", // cyan
+  "#c4b5fd", // violet
+  "#86efac", // mint
+];
+
+function randomPastelColor(): string {
+  return PASTEL_COLORS[Math.floor(Math.random() * PASTEL_COLORS.length)];
+}
+
+/** Seed workflows for the dashboard. */
+const SEED_WORKFLOWS: WorkflowSummary[] = [
+  {
+    id: "wf-1",
+    name: "Vector Store RAG",
+    updatedAt: new Date(Date.now() - 2 * 60 * 1000),
+    color: "#f9a8d4",
+  },
+  {
+    id: "wf-2",
+    name: "Basic Prompting",
+    updatedAt: new Date(Date.now() - 3 * 60 * 1000),
+    color: "#a78bfa",
+  },
+];
+
 export const useStudioStore = create<StudioState>((set, get) => ({
+  /* ── Navigation ── */
+  currentView: "dashboard",
+  workflows: SEED_WORKFLOWS,
+  activeWorkflowId: null,
+
+  createWorkflow: () => {
+    const id = nextWorkflowId();
+    const wf: WorkflowSummary = {
+      id,
+      name: "Untitled Workflow",
+      updatedAt: new Date(),
+      color: randomPastelColor(),
+    };
+    set({
+      workflows: [wf, ...get().workflows],
+      activeWorkflowId: id,
+      currentView: "editor",
+      nodes: [],
+      edges: [],
+      selectedNodeId: null,
+    });
+  },
+
+  deleteWorkflow: (id) => {
+    set({
+      workflows: get().workflows.filter((w) => w.id !== id),
+    });
+  },
+
+  openWorkflow: (id) => {
+    // For now, opening any workflow loads the sample nodes/edges.
+    // In the future each workflow will have its own persisted graph.
+    set({
+      activeWorkflowId: id,
+      currentView: "editor",
+      nodes: SAMPLE_NODES,
+      edges: SAMPLE_EDGES,
+      selectedNodeId: null,
+    });
+  },
+
+  goToDashboard: () => {
+    set({
+      currentView: "dashboard",
+      activeWorkflowId: null,
+      selectedNodeId: null,
+    });
+  },
+
+  /* ── Editor ── */
   nodes: SAMPLE_NODES,
   edges: SAMPLE_EDGES,
   selectedNodeId: null,

--- a/studio/lib/types.ts
+++ b/studio/lib/types.ts
@@ -62,3 +62,11 @@ export type BlockNode = Node<BlockNodeData>;
 
 /** `accentColor` matches the source port dot (see `getEdgeAccentColor` in `handle-colors.ts`). */
 export type BlockEdge = Edge<{ accentColor?: string }>;
+
+/** Summary entry for the workflow dashboard list. */
+export interface WorkflowSummary {
+  id: string;
+  name: string;
+  updatedAt: Date;
+  color: string;
+}

--- a/studio/lib/types.ts
+++ b/studio/lib/types.ts
@@ -69,4 +69,11 @@ export interface WorkflowSummary {
   name: string;
   updatedAt: Date;
   color: string;
+  projectId: string;
+}
+
+/** A project groups related workflows. */
+export interface Project {
+  id: string;
+  name: string;
 }


### PR DESCRIPTION
## Summary
- Add dashboard view with workflow list, nav sidebar, and top bar
- Add project sidebar with create, rename (double-click or menu), and delete
- Fix nested `<button>` hydration error by using `<div role="button">`
- Dashboard filters workflows by active project

## Test plan
- [ ] Verify dashboard loads with seed workflows under "My Project"
- [ ] Create/rename/delete projects via sidebar
- [ ] Double-click project name to inline rename
- [ ] Confirm three-dot menu dropdown renders above sidebar boundary
- [ ] Switch between dashboard and editor views