### PR TITLE
Implement orca run (uv sync + uv run)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,15 +156,25 @@ make build
 Create a file called `main.oc`:
 
 ```hcl
-model gpt4 {
-  provider    = "openai"
-  model_name  = "gpt-4o"
-  temperature = 0.7
+model gemini {
+  provider    = "google"
+  model_name  = "gemini-2.5-flash"
 }
 
-agent assistant {
-  model  = gpt4
-  persona = "You are a helpful assistant."
+agent math_expr_generator {
+  model = gemini
+  persona = "Generate a simple math expression"
+}
+
+agent math_expr_solver {
+  model = gemini
+  persona = "Solve the given math expression"
+  chain_of_thought = true
+  output_schema = number
+}
+
+workflow flow {
+  math_expr_generator -> math_expr_solver
 }
 ```
 

--- a/compiler/cmd/build.go
+++ b/compiler/cmd/build.go
@@ -23,19 +23,36 @@ var buildCmd = &cobra.Command{
 	RunE:  runBuild,
 }
 
+type compileResult struct {
+	FileCount int
+	OutputDir string
+}
+
 func init() {
 	rootCmd.AddCommand(buildCmd)
 }
 
 // runBuild is the entry point for `orca build`.
 func runBuild(cmd *cobra.Command, args []string) error {
+	result, err := compileCurrentDir()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("compiled %d .oc file(s) → %s/\n", result.FileCount, result.OutputDir)
+	return nil
+}
+
+// compileCurrentDir compiles all .oc files in the current directory and writes
+// generated output to disk.
+func compileCurrentDir() (compileResult, error) {
 	files, err := filepath.Glob("*.oc")
 	if err != nil {
-		return fmt.Errorf("failed to find .oc files: %w", err)
+		return compileResult{}, fmt.Errorf("failed to find .oc files: %w", err)
 	}
 
 	if len(files) == 0 {
-		return fmt.Errorf("no .oc files found in current directory")
+		return compileResult{}, fmt.Errorf("no .oc files found in current directory")
 	}
 
 	// Parse each file separately to preserve per-file line numbers.
@@ -43,7 +60,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	for _, file := range files {
 		data, err := os.ReadFile(file)
 		if err != nil {
-			return fmt.Errorf("failed to read %s: %w", file, err)
+			return compileResult{}, fmt.Errorf("failed to read %s: %w", file, err)
 		}
 
 		l := lexer.New(string(data), file)
@@ -54,7 +71,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			for _, d := range p.Diagnostics() {
 				fmt.Fprintf(os.Stderr, "%s:%s\n", file, d.Error())
 			}
-			return fmt.Errorf("compilation failed with parse errors")
+			return compileResult{}, fmt.Errorf("compilation failed with parse errors")
 		}
 
 		program.Statements = append(program.Statements, fileProg.Statements...)
@@ -71,7 +88,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			}
 		}
 		if hasError {
-			return fmt.Errorf("compilation failed with analysis errors")
+			return compileResult{}, fmt.Errorf("compilation failed with analysis errors")
 		}
 	}
 
@@ -89,17 +106,19 @@ func runBuild(cmd *cobra.Command, args []string) error {
 			}
 		}
 		if hasError {
-			return fmt.Errorf("compilation failed with codegen errors")
+			return compileResult{}, fmt.Errorf("compilation failed with codegen errors")
 		}
 	}
 
 	// Write output tree to disk.
 	if err := writeOutputDir(".", output.RootDir); err != nil {
-		return err
+		return compileResult{}, err
 	}
 
-	fmt.Printf("compiled %d .oc file(s) → %s/\n", len(files), output.RootDir.Name)
-	return nil
+	return compileResult{
+		FileCount: len(files),
+		OutputDir: output.RootDir.Name,
+	}, nil
 }
 
 // writeOutputDir recursively writes an OutputDirectory tree to disk under parent.

--- a/compiler/cmd/run.go
+++ b/compiler/cmd/run.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
 
 	"github.com/spf13/cobra"
 )
@@ -18,9 +20,34 @@ func init() {
 	rootCmd.AddCommand(runCmd)
 }
 
+var compileForRun = compileCurrentDir
+
+var executeCommandInDir = func(dir, name string, args ...string) error {
+	command := exec.Command(name, args...)
+	command.Dir = dir
+	command.Stdin = os.Stdin
+	command.Stdout = os.Stdout
+	command.Stderr = os.Stderr
+	return command.Run()
+}
+
 // runRun is the entry point for `orca run`.
 func runRun(cmd *cobra.Command, args []string) error {
-	// TODO: call build, then execute generated Python
-	fmt.Println("orca run: not yet implemented")
+	result, err := compileForRun()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("compiled %d .oc file(s) → %s/\n", result.FileCount, result.OutputDir)
+
+	if err := executeCommandInDir(result.OutputDir, "uv", "sync"); err != nil {
+		return fmt.Errorf("failed to run uv sync: %w", err)
+	}
+
+	uvRunArgs := append([]string{"run", "main.py"}, args...)
+	if err := executeCommandInDir(result.OutputDir, "uv", uvRunArgs...); err != nil {
+		return fmt.Errorf("failed to run uv run main.py: %w", err)
+	}
+
 	return nil
 }

--- a/compiler/cmd/run_test.go
+++ b/compiler/cmd/run_test.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+type commandCall struct {
+	Dir  string
+	Name string
+	Args []string
+}
+
+func withRunDependencies(
+	t *testing.T,
+	compileFn func() (compileResult, error),
+	execFn func(dir, name string, args ...string) error,
+) {
+	t.Helper()
+
+	previousCompile := compileForRun
+	previousExec := executeCommandInDir
+
+	compileForRun = compileFn
+	executeCommandInDir = execFn
+
+	t.Cleanup(func() {
+		compileForRun = previousCompile
+		executeCommandInDir = previousExec
+	})
+}
+
+func TestRunRunExecutesUvSyncThenUvRunWithArgs(t *testing.T) {
+	var calls []commandCall
+
+	withRunDependencies(
+		t,
+		func() (compileResult, error) {
+			return compileResult{
+				FileCount: 2,
+				OutputDir: "build",
+			}, nil
+		},
+		func(dir, name string, args ...string) error {
+			calls = append(calls, commandCall{
+				Dir:  dir,
+				Name: name,
+				Args: append([]string(nil), args...),
+			})
+			return nil
+		},
+	)
+
+	err := runRun(nil, []string{"p1", "p2", "p3"})
+	if err != nil {
+		t.Fatalf("runRun returned error: %v", err)
+	}
+
+	if len(calls) != 2 {
+		t.Fatalf("expected 2 uv command calls, got %d", len(calls))
+	}
+
+	if calls[0].Dir != "build" || calls[0].Name != "uv" {
+		t.Fatalf("unexpected first call metadata: %+v", calls[0])
+	}
+	if got := strings.Join(calls[0].Args, " "); got != "sync" {
+		t.Fatalf("unexpected first call args: %q", got)
+	}
+
+	if calls[1].Dir != "build" || calls[1].Name != "uv" {
+		t.Fatalf("unexpected second call metadata: %+v", calls[1])
+	}
+	if got := strings.Join(calls[1].Args, " "); got != "run main.py p1 p2 p3" {
+		t.Fatalf("unexpected second call args: %q", got)
+	}
+}
+
+func TestRunRunReturnsCompileErrorWithoutExecutingUv(t *testing.T) {
+	compileErr := errors.New("compile failed")
+	execCalled := false
+
+	withRunDependencies(
+		t,
+		func() (compileResult, error) {
+			return compileResult{}, compileErr
+		},
+		func(dir, name string, args ...string) error {
+			execCalled = true
+			return nil
+		},
+	)
+
+	err := runRun(nil, nil)
+	if !errors.Is(err, compileErr) {
+		t.Fatalf("expected compile error, got %v", err)
+	}
+	if execCalled {
+		t.Fatalf("uv commands should not execute when compile fails")
+	}
+}
+
+func TestRunRunStopsWhenUvSyncFails(t *testing.T) {
+	uvSyncErr := errors.New("uv sync failed")
+	callCount := 0
+
+	withRunDependencies(
+		t,
+		func() (compileResult, error) {
+			return compileResult{
+				FileCount: 1,
+				OutputDir: "build",
+			}, nil
+		},
+		func(dir, name string, args ...string) error {
+			callCount++
+			if callCount == 1 {
+				return uvSyncErr
+			}
+			return nil
+		},
+	)
+
+	err := runRun(nil, []string{"arg"})
+	if err == nil {
+		t.Fatalf("expected error when uv sync fails")
+	}
+	if !strings.Contains(err.Error(), "failed to run uv sync") {
+		t.Fatalf("expected uv sync context in error, got %q", err)
+	}
+	if callCount != 1 {
+		t.Fatalf("expected only uv sync to run, got %d calls", callCount)
+	}
+}
+
+func TestRunRunPassesFlagLikeArgsToUvRun(t *testing.T) {
+	var secondCallArgs []string
+	callCount := 0
+
+	withRunDependencies(
+		t,
+		func() (compileResult, error) {
+			return compileResult{
+				FileCount: 1,
+				OutputDir: "build",
+			}, nil
+		},
+		func(dir, name string, args ...string) error {
+			callCount++
+			if callCount == 2 {
+				secondCallArgs = append([]string(nil), args...)
+			}
+			return nil
+		},
+	)
+
+	err := runRun(nil, []string{"--foo", "bar"})
+	if err != nil {
+		t.Fatalf("runRun returned error: %v", err)
+	}
+
+	if got := strings.Join(secondCallArgs, " "); got != "run main.py --foo bar" {
+		t.Fatalf("unexpected uv run args: %q", got)
+	}
+}

--- a/compiler/types/bootstrap.oc
+++ b/compiler/types/bootstrap.oc
@@ -123,6 +123,9 @@ schema agent {
   @desc("The tools to use for this agent.")
   tools = list[tool] | null
 
+  @desc("Whether to use chain of thought for the agent.")
+  chain_of_thought = bool | null
+
   @desc("The structured output schema for this agent.")
   output_schema = schema | null
 }

--- a/compiler/types/bootstrap_test.go
+++ b/compiler/types/bootstrap_test.go
@@ -40,7 +40,7 @@ func TestLoadSchemas(t *testing.T) {
 		{"any", "any", 0},
 		{"null", "null", 0},
 		{"model", "model", 5},
-		{"agent", "agent", 4},
+		{"agent", "agent", 5},
 		{"tool", "tool", 4},
 		{"knowledge", "knowledge", 1},
 		{"workflow", "workflow", 2},

--- a/compiler/types/schema_test.go
+++ b/compiler/types/schema_test.go
@@ -44,7 +44,7 @@ func TestGetBlockSchema(t *testing.T) {
 		numFields int
 	}{
 		{"model schema exists", "model", true, 5},
-		{"agent schema exists", "agent", true, 4},
+		{"agent schema exists", "agent", true, 5},
 		{"tool schema exists", "tool", true, 4},
 		{"knowledge schema exists", "knowledge", true, 1},
 		{"workflow schema exists", "workflow", true, 2},

--- a/docs/guide/cli.md
+++ b/docs/guide/cli.md
@@ -43,6 +43,14 @@ Builds and runs the generated Python code.
 orca run
 ```
 
-::: warning
-This command is not yet implemented.
-:::
+**Behavior:**
+- Runs the same compile pipeline as `orca build`.
+- Runs `uv sync` in the generated `build/` directory.
+- Runs `uv run main.py` in the `build/` directory.
+- Passes runtime arguments through to `uv run main.py`.
+
+**Examples:**
+```bash
+orca run p1 p2 p3
+orca run -- --foo bar
+```


### PR DESCRIPTION
## Summary

This PR implements `orca run` by reusing the same compile pipeline as `orca build`, then running `uv sync` and `uv run main.py` in the generated output directory (with arguments forwarded to Python).

## Changes

- **Build**: Extract `compileCurrentDir()` and `compileResult` so `run` can call the same pipeline without duplicating logic.
- **Run**: After a successful compile, run `uv sync` then `uv run main.py` with stdin/stdout/stderr wired through; pass-through args support flag-like values (e.g. `orca run -- --foo bar`).
- **Types**: Add optional `chain_of_thought` to the `agent` schema in `bootstrap.oc`; update schema field-count tests.
- **Docs**: Update CLI guide and README quickstart (workflow example with Gemini agents).
- **Tests**: Add `compiler/cmd/run_test.go` with injectable compile/exec hooks.

## Testing

`cd compiler && go test ./...` passes locally.

## Notes

Requires `uv` on PATH for `orca run`.

Made with [Cursor](https://cursor.com)