### PR TITLE
Compiler: graph package, block dependency order, workflow graph refactor

### DIFF
--- a/compiler/analyzer/analyzer.go
+++ b/compiler/analyzer/analyzer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/thakee/orca/compiler/ast"
 	"github.com/thakee/orca/compiler/diagnostic"
+	"github.com/thakee/orca/compiler/graph"
 	"github.com/thakee/orca/compiler/helper"
 	"github.com/thakee/orca/compiler/token"
 	"github.com/thakee/orca/compiler/types"
@@ -26,6 +27,11 @@ type AnalyzedProgram struct {
 	Ast         *ast.Program
 	SymbolTable *types.SymbolTable
 	Diagnostics []diagnostic.Diagnostic
+
+	// BlockOrder is the topologically sorted list of user-defined block names.
+	// Blocks with no dependencies come first; dependents come after their
+	// dependencies. Codegen uses this to emit blocks in valid definition order.
+	BlockOrder []string
 }
 
 // Analyze walks the AST and performs semantic analysis.
@@ -46,6 +52,7 @@ func Analyze(program *ast.Program) AnalyzedProgram {
 
 	buildSymbolTable(&ap)
 	resolveBlockSchemaReferences(&ap)
+	buildBlockDependencyGraph(&ap)
 
 	for _, stmt := range program.Statements {
 		// We dont have any other statement than BlockStatement, maybe
@@ -159,6 +166,117 @@ func resolveBlockSchemaReferences(ap *AnalyzedProgram) {
 
 	for _, symbol := range ap.SymbolTable.GetSymbols() {
 		resolveTypeBlockReference(&symbol.Type, ap.SymbolTable)
+	}
+}
+
+// buildBlockDependencyGraph constructs a directed graph of block-to-block
+// dependencies by walking each block's expressions for references to other
+// user-defined blocks. The graph is topologically sorted to produce a valid
+// emission order for codegen. Cycles are reported as diagnostics.
+func buildBlockDependencyGraph(ap *AnalyzedProgram) {
+	g := graph.New[string]()
+
+	// Collect user-defined block names (everything not from bootstrap).
+	userBlocks := make(map[string]*ast.BlockStatement)
+	for _, stmt := range ap.Ast.Statements {
+		block, ok := stmt.(*ast.BlockStatement)
+		if !ok {
+			continue
+		}
+		userBlocks[block.Name] = block
+		g.AddNode(block.Name)
+	}
+
+	// Extract dependencies: for each block, walk its body and find
+	// references to other user-defined blocks.
+	for _, stmt := range ap.Ast.Statements {
+		block, ok := stmt.(*ast.BlockStatement)
+		if !ok {
+			continue
+		}
+		deps := make(map[string]bool)
+		for _, assign := range block.BlockBody.Assignments {
+			if assign.Value != nil {
+				collectBlockDeps(assign.Value, userBlocks, deps)
+			}
+		}
+		for _, expr := range block.BlockBody.Expressions {
+			collectBlockDeps(expr, userBlocks, deps)
+		}
+		for dep := range deps {
+			if dep != block.Name { // skip self-references (handled by other checks)
+				g.AddEdge(dep, block.Name)
+			}
+		}
+	}
+
+	// Topological sort — reverse because edges point from dependent → dependency,
+	// so dependencies must be emitted first.
+	sorted, err := g.TopologicalSort()
+	if err != nil {
+		// Report cycle diagnostic on each block involved.
+		// Since we can't easily pinpoint exactly which blocks form the cycle,
+		// report on all blocks that weren't emitted by the sort.
+		ap.Diagnostics = append(ap.Diagnostics, diagnostic.Diagnostic{
+			Severity: diagnostic.Error,
+			Code:     diagnostic.CodeCyclicDependency,
+			Position: diagnostic.Position{Line: 1, Column: 1},
+			Message:  fmt.Sprintf("block dependency cycle detected: %s", err),
+			Source:   "analyzer",
+		})
+		// Fall back to source order when there's a cycle.
+		ap.BlockOrder = g.Nodes()
+		return
+	}
+
+	ap.BlockOrder = sorted
+}
+
+// collectBlockDeps recursively walks an expression and collects the names of
+// any user-defined blocks it references.
+func collectBlockDeps(expr ast.Expression, userBlocks map[string]*ast.BlockStatement, deps map[string]bool) {
+	if expr == nil {
+		return
+	}
+	switch e := expr.(type) {
+	case *ast.Identifier:
+		if _, ok := userBlocks[e.Value]; ok {
+			deps[e.Value] = true
+		}
+	case *ast.MemberAccess:
+		// The dependency is on the root object, not the member.
+		collectBlockDeps(e.Object, userBlocks, deps)
+	case *ast.BinaryExpression:
+		collectBlockDeps(e.Left, userBlocks, deps)
+		collectBlockDeps(e.Right, userBlocks, deps)
+	case *ast.ListLiteral:
+		for _, elem := range e.Elements {
+			collectBlockDeps(elem, userBlocks, deps)
+		}
+	case *ast.MapLiteral:
+		for _, entry := range e.Entries {
+			collectBlockDeps(entry.Key, userBlocks, deps)
+			collectBlockDeps(entry.Value, userBlocks, deps)
+		}
+	case *ast.CallExpression:
+		collectBlockDeps(e.Callee, userBlocks, deps)
+		for _, arg := range e.Arguments {
+			collectBlockDeps(arg, userBlocks, deps)
+		}
+	case *ast.Subscription:
+		collectBlockDeps(e.Object, userBlocks, deps)
+		if e.Index != nil {
+			collectBlockDeps(e.Index, userBlocks, deps)
+		}
+	case *ast.BlockExpression:
+		for _, assign := range e.BlockBody.Assignments {
+			if assign.Value != nil {
+				collectBlockDeps(assign.Value, userBlocks, deps)
+			}
+		}
+		for _, subExpr := range e.BlockBody.Expressions {
+			collectBlockDeps(subExpr, userBlocks, deps)
+		}
 	}
 }
 

--- a/compiler/analyzer/analyzer_test.go
+++ b/compiler/analyzer/analyzer_test.go
@@ -1441,3 +1441,103 @@ func TestAnalyzeWorkflowEntryNodes(t *testing.T) {
 		})
 	}
 }
+
+// TestBlockDependencyOrder verifies that the analyzer produces a topologically
+// sorted BlockOrder where dependencies come before dependents.
+func TestBlockDependencyOrder(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		expectedOrder []string
+	}{
+		{
+			name: "model before let that references it",
+			input: `
+				model o { provider = "openai" model_name = "gpt-4o" }
+				let vars { m = o }
+			`,
+			expectedOrder: []string{"o", "vars"},
+		},
+		{
+			name: "model before agent that references it",
+			input: `
+				agent a1 { model = gpt persona = "test" }
+				model gpt { provider = "openai" model_name = "gpt-4o" }
+			`,
+			expectedOrder: []string{"gpt", "a1"},
+		},
+		{
+			name: "let referencing model, agent referencing let",
+			input: `
+				agent a1 { model = vars.m persona = "test" }
+				let vars { m = o }
+				model o { provider = "openai" model_name = "gpt-4o" }
+			`,
+			expectedOrder: []string{"o", "vars", "a1"},
+		},
+		{
+			name: "independent blocks preserve source order",
+			input: `
+				model a { provider = "openai" model_name = "a" }
+				model b { provider = "openai" model_name = "b" }
+			`,
+			expectedOrder: []string{"a", "b"},
+		},
+		{
+			name: "workflow depends on agents",
+			input: `
+				model m { provider = "openai" model_name = "gpt-4o" }
+				agent a1 { model = m persona = "p1" }
+				agent a2 { model = m persona = "p2" }
+				workflow flow { a1 -> a2 }
+			`,
+			expectedOrder: []string{"m", "a1", "a2", "flow"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			program := parseProgram(t, tt.input)
+			result := Analyze(program)
+
+			for _, d := range result.Diagnostics {
+				if d.Severity == diagnostic.Error && d.Code != diagnostic.CodeMissingField {
+					t.Fatalf("unexpected error: %s", d.Message)
+				}
+			}
+
+			if len(result.BlockOrder) != len(tt.expectedOrder) {
+				t.Fatalf("BlockOrder length = %d, want %d\ngot:  %v\nwant: %v",
+					len(result.BlockOrder), len(tt.expectedOrder), result.BlockOrder, tt.expectedOrder)
+			}
+			for i, name := range result.BlockOrder {
+				if name != tt.expectedOrder[i] {
+					t.Errorf("BlockOrder[%d] = %q, want %q\nfull order: %v",
+						i, name, tt.expectedOrder[i], result.BlockOrder)
+				}
+			}
+		})
+	}
+}
+
+// TestBlockDependencyCycleError verifies that cyclic block dependencies
+// produce a diagnostic error.
+func TestBlockDependencyCycleError(t *testing.T) {
+	input := `
+		let a { x = b }
+		let b { y = a }
+	`
+	program := parseProgram(t, input)
+	result := Analyze(program)
+
+	found := false
+	for _, d := range result.Diagnostics {
+		if d.Code == diagnostic.CodeCyclicDependency {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected cyclic-dependency diagnostic, got: %v", result.Diagnostics)
+	}
+}

--- a/compiler/codegen/codegen.go
+++ b/compiler/codegen/codegen.go
@@ -77,3 +77,13 @@ func (b *BaseBackend) CollectBlocksByKind(kind string) []*ast.BlockStatement {
 func (b *BaseBackend) CollectLets() []*ast.BlockStatement {
 	return b.CollectBlocksByKind(analyzer.BlockKindLet)
 }
+
+// BlockByName returns the block statement with the given name, or nil if not found.
+func (b *BaseBackend) BlockByName(name string) *ast.BlockStatement {
+	for _, stmt := range b.Program.Ast.Statements {
+		if block, ok := stmt.(*ast.BlockStatement); ok && block.Name == name {
+			return block
+		}
+	}
+	return nil
+}

--- a/compiler/codegen/langgraph/langgraph.go
+++ b/compiler/codegen/langgraph/langgraph.go
@@ -81,14 +81,7 @@ func (b *LangGraphBackend) generateMain() string {
 	s.WriteString("\n")
 
 	b.writeSchemaSection(&s, schemaBlocks)
-	b.writeModelSection(&s)
-	b.writeOrcaBlockSection(&s, "Knowledge", analyzer.BlockKindKnowledge)
-	b.writeToolSection(&s)
-	b.writeOrcaBlockSection(&s, "Variables", analyzer.BlockKindLet)
-	b.writeOrcaBlockSection(&s, "Agents", analyzer.BlockKindAgent)
-	b.writeOrcaBlockSection(&s, "Cron", analyzer.BlockKindCron)
-	b.writeOrcaBlockSection(&s, "Webhooks", analyzer.BlockKindWebhook)
-	b.writeWorkflowSection(&s, workflows)
+	b.writeBlocksInOrder(&s)
 
 	b.writeWorkflowEntrypoint(&s)
 
@@ -103,18 +96,56 @@ func (b *LangGraphBackend) writeImports(s *strings.Builder, providerImports []py
 	}
 }
 
-// writeOrcaBlockSection emits all top-level blocks of the given kind as
-// `name = __orca_<kind>(...)` under "# --- <sectionTitle> ---". Skips the section when empty.
-func (b *LangGraphBackend) writeOrcaBlockSection(s *strings.Builder, sectionTitle string, kind string) {
-	blocks := b.CollectBlocksByKind(kind)
-	if len(blocks) == 0 {
-		return
-	}
-	s.WriteString("\n# --- " + sectionTitle + " ---\n")
-	for _, block := range blocks {
+// writeBlocksInOrder emits all user-defined blocks in topological dependency
+// order (from AnalyzedProgram.BlockOrder).
+func (b *LangGraphBackend) writeBlocksInOrder(s *strings.Builder) {
+	for _, name := range b.Program.BlockOrder {
+		block := b.BlockByName(name)
 		if block == nil {
-			panic("BUG: writeOrcaBlockSection collected nil block")
+			continue
 		}
+
+		// Skip schema blocks — they're handled separately.
+		if block.Kind == types.BlockKindSchema {
+			continue
+		}
+
+		b.writeBlock(s, block)
+	}
+}
+
+// writeBlock emits a single block, dispatching to the appropriate writer
+// based on block kind.
+func (b *LangGraphBackend) writeBlock(s *strings.Builder, block *ast.BlockStatement) {
+	switch block.Kind {
+	case analyzer.BlockKindModel:
+		s.WriteString("\n")
+		fmt.Fprintf(s, "%s = %s\n", block.Name, modelBlockSource(block))
+
+	case analyzer.BlockKindTool:
+		resolved, ok := b.resolvedTools[block.Name]
+		if !ok {
+			s.WriteString("\n")
+			fmt.Fprintf(s, "%s = %s\n", block.Name, topLevelBlockSource(block))
+			return
+		}
+		if resolved.verbatim != "" {
+			s.WriteString("\n")
+			s.WriteString(resolved.verbatim)
+			s.WriteString("\n")
+		}
+		s.WriteString("\n")
+		fmt.Fprintf(s, "%s = %s\n", block.Name, toolBlockSource(block, resolved.invokeRef))
+
+	case analyzer.BlockKindWorkflow:
+		if rw, ok := b.resolvedWorkflows[block.Name]; ok {
+			if len(rw.Nodes) > 0 {
+				b.writeWorkflow(s, rw)
+			}
+		}
+
+	default:
+		// Generic block: let, agent, knowledge, cron, webhook.
 		s.WriteString("\n")
 		fmt.Fprintf(s, "%s = %s\n", block.Name, topLevelBlockSource(block))
 	}
@@ -126,7 +157,7 @@ func (b *LangGraphBackend) writeSchemaSection(s *strings.Builder, blocks []*ast.
 	if len(blocks) == 0 {
 		return
 	}
-	s.WriteString("\n# --- Schemas ---\n")
+	s.WriteString("\n")
 	for _, block := range blocks {
 		s.WriteString("\n")
 		s.WriteString(python.SchemaBlockToSource(block))

--- a/compiler/codegen/langgraph/langgraph.go
+++ b/compiler/codegen/langgraph/langgraph.go
@@ -81,10 +81,10 @@ func (b *LangGraphBackend) generateMain() string {
 	s.WriteString("\n")
 
 	b.writeSchemaSection(&s, schemaBlocks)
-	b.writeOrcaBlockSection(&s, "Variables", analyzer.BlockKindLet)
 	b.writeModelSection(&s)
 	b.writeOrcaBlockSection(&s, "Knowledge", analyzer.BlockKindKnowledge)
 	b.writeToolSection(&s)
+	b.writeOrcaBlockSection(&s, "Variables", analyzer.BlockKindLet)
 	b.writeOrcaBlockSection(&s, "Agents", analyzer.BlockKindAgent)
 	b.writeOrcaBlockSection(&s, "Cron", analyzer.BlockKindCron)
 	b.writeOrcaBlockSection(&s, "Webhooks", analyzer.BlockKindWebhook)

--- a/compiler/codegen/langgraph/langgraph_test.go
+++ b/compiler/codegen/langgraph/langgraph_test.go
@@ -100,65 +100,41 @@ func TestCollectBlocksByKind(t *testing.T) {
 	}
 }
 
-// TestWriteOrcaBlockSection verifies section headers and per-block emission for a given block kind.
-func TestWriteOrcaBlockSection(t *testing.T) {
+// TestWriteBlocksInOrder verifies section headers and per-block emission
+// using topological dependency order.
+func TestWriteBlocksInOrder(t *testing.T) {
 	tests := []struct {
 		name           string
 		program        *ast.Program
-		sectionTitle   string
-		kind           string
 		wantEmpty      bool
 		wantSubstrings []string
 	}{
 		{
-			name:           "empty program emits nothing",
-			program:        &ast.Program{},
-			sectionTitle:   "Models",
-			kind:           analyzer.BlockKindModel,
-			wantEmpty:      true,
-			wantSubstrings: nil,
+			name:      "empty program emits nothing",
+			program:   &ast.Program{},
+			wantEmpty: true,
 		},
 		{
-			name:         "one model block",
-			program:      programWithModels(modelBlock("gpt4", "openai", "gpt-4o")),
-			sectionTitle: "Models",
-			kind:         analyzer.BlockKindModel,
+			name:    "one model block",
+			program: programWithModels(modelBlock("gpt4", "openai", "gpt-4o")),
 			wantSubstrings: []string{
-				"\n# --- Models ---\n",
-				"\n\ngpt4 = __orca_model(\n",
-				`    provider="openai",`,
+				"gpt4 = __orca_model(\n",
+				"provider_class=ChatOpenAI",
 			},
 		},
 		{
-			name:         "two agent blocks preserve order",
-			program:      &ast.Program{Statements: []ast.Statement{agentBlock("a1", "m", "p1"), agentBlock("a2", "m", "p2")}},
-			sectionTitle: "Agents",
-			kind:         analyzer.BlockKindAgent,
+			name:    "two agent blocks preserve order",
+			program: &ast.Program{Statements: []ast.Statement{agentBlock("a1", "m", "p1"), agentBlock("a2", "m", "p2")}},
 			wantSubstrings: []string{
-				"\n# --- Agents ---\n",
 				"a1 = __orca_agent(",
 				"a2 = __orca_agent(",
 			},
 		},
+		// Schema blocks are handled separately by writeSchemaSection, not writeBlocksInOrder.
 		{
-			name:         "schema block",
-			program:      &ast.Program{Statements: []ast.Statement{schemaBlock("vpc_data_t", schemaField{"region", "string"}, schemaField{"count", "int"})}},
-			sectionTitle: "Schemas",
-			kind:         types.BlockKindSchema,
+			name:    "knowledge block",
+			program: &ast.Program{Statements: []ast.Statement{knowledgeBlock("docs", "Company wiki")}},
 			wantSubstrings: []string{
-				"\n# --- Schemas ---\n",
-				"vpc_data_t = __orca_schema(\n",
-				"    region=str,\n",
-				"    count=int,\n",
-			},
-		},
-		{
-			name:         "knowledge block",
-			program:      &ast.Program{Statements: []ast.Statement{knowledgeBlock("docs", "Company wiki")}},
-			sectionTitle: "Knowledge",
-			kind:         analyzer.BlockKindKnowledge,
-			wantSubstrings: []string{
-				"\n# --- Knowledge ---\n",
 				"docs = __orca_knowledge(\n",
 				`    desc="Company wiki",`,
 			},
@@ -167,9 +143,11 @@ func TestWriteOrcaBlockSection(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			b := &LangGraphBackend{BaseBackend: codegen.BaseBackend{Program: analyzedProgram(tt.program)}}
+			ap := analyzedProgram(tt.program)
+			b := &LangGraphBackend{BaseBackend: codegen.BaseBackend{Program: ap}}
+			b.resolveWorkflows()
 			var s strings.Builder
-			b.writeOrcaBlockSection(&s, tt.sectionTitle, tt.kind)
+			b.writeBlocksInOrder(&s)
 			got := s.String()
 			if tt.wantEmpty {
 				if got != "" {

--- a/compiler/codegen/testdata/golden/agent_basic.py
+++ b/compiler/codegen/testdata/golden/agent_basic.py
@@ -164,14 +164,10 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 writer = __orca_agent(
     model=gpt4,

--- a/compiler/codegen/testdata/golden/agent_field_annotated.py
+++ b/compiler/codegen/testdata/golden/agent_field_annotated.py
@@ -164,14 +164,10 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 writer = __orca_agent(
     model=__orca_with_meta(

--- a/compiler/codegen/testdata/golden/agent_with_tools.py
+++ b/compiler/codegen/testdata/golden/agent_with_tools.py
@@ -164,15 +164,11 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
     temperature=0.5,
 )
-
-# --- Tools ---
 
 def web_search__invoke_verbatim(query: str) -> str:
     return ""
@@ -187,8 +183,6 @@ def calculator__invoke_verbatim(expr: str) -> str:
 calculator = __orca_tool(
     invoke=calculator__invoke_verbatim,
 )
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,

--- a/compiler/codegen/testdata/golden/knowledge_basic.py
+++ b/compiler/codegen/testdata/golden/knowledge_basic.py
@@ -163,8 +163,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Knowledge ---
-
 docs = __orca_knowledge(
     desc="Company knowledge base",
 )

--- a/compiler/codegen/testdata/golden/let_basic.py
+++ b/compiler/codegen/testdata/golden/let_basic.py
@@ -163,8 +163,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Variables ---
-
 vars = __orca_let(
     api_url="https://api.example.com",
     max_retries=3,

--- a/compiler/codegen/testdata/golden/let_expressions.py
+++ b/compiler/codegen/testdata/golden/let_expressions.py
@@ -163,8 +163,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Variables ---
-
 vars = __orca_let(
     name="orca",
     count=42,

--- a/compiler/codegen/testdata/golden/mixed_let_model.py
+++ b/compiler/codegen/testdata/golden/mixed_let_model.py
@@ -164,16 +164,12 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
+vars = __orca_let(
+    api_key="sk-123",
+)
 
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
     temperature=1,
-)
-
-# --- Variables ---
-
-vars = __orca_let(
-    api_key="sk-123",
 )

--- a/compiler/codegen/testdata/golden/mixed_let_model.py
+++ b/compiler/codegen/testdata/golden/mixed_let_model.py
@@ -164,16 +164,16 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Variables ---
-
-vars = __orca_let(
-    api_key="sk-123",
-)
-
 # --- Models ---
 
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
     temperature=1,
+)
+
+# --- Variables ---
+
+vars = __orca_let(
+    api_key="sk-123",
 )

--- a/compiler/codegen/testdata/golden/model_basic.py
+++ b/compiler/codegen/testdata/golden/model_basic.py
@@ -164,15 +164,11 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
     temperature=0.7,
 )
-
-# --- Agents ---
 
 writer = __orca_agent(
     model=gpt4,

--- a/compiler/codegen/testdata/golden/model_field_annotated.py
+++ b/compiler/codegen/testdata/golden/model_field_annotated.py
@@ -164,8 +164,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",

--- a/compiler/codegen/testdata/golden/model_multi_provider.py
+++ b/compiler/codegen/testdata/golden/model_multi_provider.py
@@ -166,8 +166,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",

--- a/compiler/codegen/testdata/golden/model_no_temperature.py
+++ b/compiler/codegen/testdata/golden/model_no_temperature.py
@@ -164,8 +164,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 claude = __orca_model(
     provider_class=ChatAnthropic,
     model_name="claude-sonnet-4-20250514",

--- a/compiler/codegen/testdata/golden/multi_agent.py
+++ b/compiler/codegen/testdata/golden/multi_agent.py
@@ -165,8 +165,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
@@ -177,8 +175,6 @@ claude = __orca_model(
     model_name="claude-sonnet-4-20250514",
     temperature=0.3,
 )
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,

--- a/compiler/codegen/testdata/golden/schema_basic.py
+++ b/compiler/codegen/testdata/golden/schema_basic.py
@@ -164,7 +164,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Schemas ---
 
 class vpc_data_t(BaseModel):
     region: str

--- a/compiler/codegen/testdata/golden/schema_field_desc.py
+++ b/compiler/codegen/testdata/golden/schema_field_desc.py
@@ -164,7 +164,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Schemas ---
 
 class vpc_data_t(BaseModel):
     region: str = Field(description="AWS region")

--- a/compiler/codegen/testdata/golden/schema_field_multi_ann.py
+++ b/compiler/codegen/testdata/golden/schema_field_multi_ann.py
@@ -164,7 +164,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Schemas ---
 
 class cfg(BaseModel):
     region: str = Field(description="Region code")

--- a/compiler/codegen/testdata/golden/schema_nested.py
+++ b/compiler/codegen/testdata/golden/schema_nested.py
@@ -164,7 +164,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Schemas ---
 
 class address(BaseModel):
     street: str = Field(description="Street name")

--- a/compiler/codegen/testdata/golden/schema_pydantic.py
+++ b/compiler/codegen/testdata/golden/schema_pydantic.py
@@ -165,21 +165,16 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Schemas ---
 
 class research_report(BaseModel):
     topic: str = Field(description="The research topic")
     findings: list[str] = Field(description="Key findings from research")
     score: float | None = Field(default=None, description="Confidence score")
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,

--- a/compiler/codegen/testdata/golden/workflow_basic.py
+++ b/compiler/codegen/testdata/golden/workflow_basic.py
@@ -165,14 +165,10 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,
@@ -183,8 +179,6 @@ writer = __orca_agent(
     model=gpt4,
     persona="You write polished articles.",
 )
-
-# --- Workflows ---
 
 class __orca_state_pipeline(TypedDict):
     __orca_trigger: str | None

--- a/compiler/codegen/testdata/golden/workflow_cron_webhook.py
+++ b/compiler/codegen/testdata/golden/workflow_cron_webhook.py
@@ -165,14 +165,10 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,
@@ -184,19 +180,13 @@ writer = __orca_agent(
     persona="You write polished articles.",
 )
 
-# --- Cron ---
-
 daily = __orca_cron(
     schedule="0 9 * * *",
 )
 
-# --- Webhooks ---
-
 hooks_in = __orca_webhook(
     path="/hooks/in",
 )
-
-# --- Workflows ---
 
 class __orca_state_pipeline(TypedDict):
     __orca_trigger: str | None

--- a/compiler/codegen/testdata/golden/workflow_diamond.py
+++ b/compiler/codegen/testdata/golden/workflow_diamond.py
@@ -165,14 +165,10 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 classifier = __orca_agent(
     model=gpt4,
@@ -193,8 +189,6 @@ reviewer = __orca_agent(
     model=gpt4,
     persona="You review and merge results.",
 )
-
-# --- Workflows ---
 
 class __orca_state_diamond(TypedDict):
     __orca_trigger: str | None

--- a/compiler/codegen/testdata/golden/workflow_empty.py
+++ b/compiler/codegen/testdata/golden/workflow_empty.py
@@ -164,8 +164,6 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",

--- a/compiler/codegen/testdata/golden/workflow_fan_out.py
+++ b/compiler/codegen/testdata/golden/workflow_fan_out.py
@@ -165,14 +165,10 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,
@@ -189,13 +185,9 @@ writer = __orca_agent(
     persona="You write polished articles.",
 )
 
-# --- Cron ---
-
 daily = __orca_cron(
     schedule="0 9 * * *",
 )
-
-# --- Workflows ---
 
 class __orca_state_pipeline(TypedDict):
     __orca_trigger: str | None

--- a/compiler/codegen/testdata/golden/workflow_mixed_nodes.py
+++ b/compiler/codegen/testdata/golden/workflow_mixed_nodes.py
@@ -166,28 +166,14 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Schemas ---
 
 class report(BaseModel):
     content: str
-
-# --- Models ---
 
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Tools ---
-
-def validate__invoke_verbatim(report: str) -> str:
-    return report
-
-validate = __orca_tool(
-    invoke=validate__invoke_verbatim,
-)
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,
@@ -200,7 +186,12 @@ writer = __orca_agent(
     output_schema=report,
 )
 
-# --- Workflows ---
+def validate__invoke_verbatim(report: str) -> str:
+    return report
+
+validate = __orca_tool(
+    invoke=validate__invoke_verbatim,
+)
 
 class __orca_state_pipeline(TypedDict):
     __orca_trigger: str | None

--- a/compiler/codegen/testdata/golden/workflow_multi_chain.py
+++ b/compiler/codegen/testdata/golden/workflow_multi_chain.py
@@ -165,14 +165,10 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,
@@ -188,8 +184,6 @@ reviewer = __orca_agent(
     model=gpt4,
     persona="You review articles.",
 )
-
-# --- Workflows ---
 
 class __orca_state_pipeline(TypedDict):
     __orca_trigger: str | None

--- a/compiler/codegen/testdata/golden/workflow_multi_trigger.py
+++ b/compiler/codegen/testdata/golden/workflow_multi_trigger.py
@@ -165,14 +165,10 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,
@@ -189,19 +185,13 @@ writer = __orca_agent(
     persona="You write polished articles.",
 )
 
-# --- Cron ---
-
 daily = __orca_cron(
     schedule="0 9 * * *",
 )
 
-# --- Webhooks ---
-
 hooks_in = __orca_webhook(
     path="/hooks/in",
 )
-
-# --- Workflows ---
 
 class __orca_state_pipeline(TypedDict):
     __orca_trigger: str | None

--- a/compiler/codegen/testdata/golden/workflow_no_trigger.py
+++ b/compiler/codegen/testdata/golden/workflow_no_trigger.py
@@ -165,14 +165,10 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,
@@ -183,8 +179,6 @@ writer = __orca_agent(
     model=gpt4,
     persona="You write polished articles.",
 )
-
-# --- Workflows ---
 
 class __orca_state_pipeline(TypedDict):
     __orca_trigger: str | None

--- a/compiler/codegen/testdata/golden/workflow_single_agent.py
+++ b/compiler/codegen/testdata/golden/workflow_single_agent.py
@@ -165,21 +165,15 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
 
-# --- Agents ---
-
 researcher = __orca_agent(
     model=gpt4,
     persona="You research topics thoroughly.",
 )
-
-# --- Workflows ---
 
 class __orca_state_pipeline(TypedDict):
     __orca_trigger: str | None

--- a/compiler/codegen/testdata/golden/workflow_tool_node.py
+++ b/compiler/codegen/testdata/golden/workflow_tool_node.py
@@ -165,14 +165,15 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
 
-# --- Tools ---
+drafter = __orca_agent(
+    model=gpt4,
+    persona="You draft reports.",
+)
 
 def validate__invoke_verbatim(report: str) -> str:
     return report
@@ -182,19 +183,10 @@ validate = __orca_tool(
     invoke=validate__invoke_verbatim,
 )
 
-# --- Agents ---
-
-drafter = __orca_agent(
-    model=gpt4,
-    persona="You draft reports.",
-)
-
 reviewer = __orca_agent(
     model=gpt4,
     persona="You review validated reports.",
 )
-
-# --- Workflows ---
 
 class __orca_state_review_pipeline(TypedDict):
     __orca_trigger: str | None

--- a/compiler/codegen/testdata/golden/workflow_typed_state.py
+++ b/compiler/codegen/testdata/golden/workflow_typed_state.py
@@ -166,20 +166,15 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Schemas ---
 
 class report(BaseModel):
     content: str = Field(description="The report content")
     score: int = Field(description="Quality score")
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,
@@ -191,8 +186,6 @@ writer = __orca_agent(
     persona="Write reports.",
     output_schema=report,
 )
-
-# --- Workflows ---
 
 class __orca_state_pipeline(TypedDict):
     __orca_trigger: str | None

--- a/compiler/codegen/testdata/golden/workflow_with_fields.py
+++ b/compiler/codegen/testdata/golden/workflow_with_fields.py
@@ -165,14 +165,10 @@ def __orca_invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
     return tool.invoke(input_data)
 
 
-# --- Models ---
-
 gpt4 = __orca_model(
     provider_class=ChatOpenAI,
     model_name="gpt-4o",
 )
-
-# --- Agents ---
 
 researcher = __orca_agent(
     model=gpt4,
@@ -183,8 +179,6 @@ writer = __orca_agent(
     model=gpt4,
     persona="You write articles.",
 )
-
-# --- Workflows ---
 
 class __orca_state_pipeline(TypedDict):
     __orca_trigger: str | None

--- a/compiler/diagnostic/diagnostic.go
+++ b/compiler/diagnostic/diagnostic.go
@@ -42,6 +42,7 @@ const (
 	CodeTriggerAsTarget  = "trigger-as-target"     // trigger block used as edge target instead of source
 	CodeAmbiguousStart   = "ambiguous-start"       // multiple entry nodes without triggers to disambiguate
 	CodeDanglingEntry    = "dangling-entry"        // entry node unreachable because no trigger points to it
+	CodeCyclicDependency = "cyclic-dependency"     // blocks form a dependency cycle
 )
 
 // Diagnostic represents a single compiler message (error, warning, etc.)

--- a/compiler/graph/graph.go
+++ b/compiler/graph/graph.go
@@ -1,0 +1,212 @@
+// Package graph provides a generic directed graph with insertion-ordered nodes.
+// It supports topological sorting (Kahn's algorithm), cycle detection, and
+// reachability queries. Used by the analyzer for block dependency ordering
+// and by the workflow package for control flow graphs.
+package graph
+
+import "fmt"
+
+// Edge represents a directed edge from one node to another.
+type Edge[K comparable] struct {
+	From K
+	To   K
+}
+
+// Graph is a generic directed graph with insertion-ordered nodes.
+// Nodes are identified by keys of type K. Duplicate nodes and edges
+// are silently ignored, preserving the first insertion order.
+type Graph[K comparable] struct {
+	nodes []K            // insertion-ordered node list
+	seen  map[K]bool     // dedup set for nodes
+	adj   map[K][]K      // outgoing edges (adjacency list)
+	inAdj map[K][]K      // incoming edges (reverse adjacency list)
+	edges []Edge[K]      // insertion-ordered edge list
+	edgeSet map[[2]K]bool // dedup set for edges
+}
+
+// New creates an empty directed graph.
+func New[K comparable]() *Graph[K] {
+	return &Graph[K]{
+		seen:    make(map[K]bool),
+		adj:     make(map[K][]K),
+		inAdj:   make(map[K][]K),
+		edgeSet: make(map[[2]K]bool),
+	}
+}
+
+// AddNode adds a node to the graph. If the node already exists, this is a no-op.
+func (g *Graph[K]) AddNode(node K) {
+	if g.seen[node] {
+		return
+	}
+	g.seen[node] = true
+	g.nodes = append(g.nodes, node)
+}
+
+// AddEdge adds a directed edge from -> to. Both nodes are implicitly added
+// if they don't already exist. Duplicate edges are ignored.
+func (g *Graph[K]) AddEdge(from, to K) {
+	g.AddNode(from)
+	g.AddNode(to)
+	key := [2]K{from, to}
+	if g.edgeSet[key] {
+		return
+	}
+	g.edgeSet[key] = true
+	g.edges = append(g.edges, Edge[K]{From: from, To: to})
+	g.adj[from] = append(g.adj[from], to)
+	g.inAdj[to] = append(g.inAdj[to], from)
+}
+
+// Nodes returns all nodes in insertion order.
+func (g *Graph[K]) Nodes() []K {
+	return g.nodes
+}
+
+// Edges returns all edges in insertion order.
+func (g *Graph[K]) Edges() []Edge[K] {
+	return g.edges
+}
+
+// HasNode returns true if the node exists in the graph.
+func (g *Graph[K]) HasNode(node K) bool {
+	return g.seen[node]
+}
+
+// HasEdge returns true if the directed edge from -> to exists.
+func (g *Graph[K]) HasEdge(from, to K) bool {
+	return g.edgeSet[[2]K{from, to}]
+}
+
+// Successors returns the outgoing neighbors of a node in insertion order.
+// Returns nil if the node has no outgoing edges or doesn't exist.
+func (g *Graph[K]) Successors(node K) []K {
+	return g.adj[node]
+}
+
+// Predecessors returns the incoming neighbors of a node in insertion order.
+// Returns nil if the node has no incoming edges or doesn't exist.
+func (g *Graph[K]) Predecessors(node K) []K {
+	return g.inAdj[node]
+}
+
+// EntryNodes returns nodes with no incoming edges, in insertion order.
+func (g *Graph[K]) EntryNodes() []K {
+	var entries []K
+	for _, n := range g.nodes {
+		if len(g.inAdj[n]) == 0 {
+			entries = append(entries, n)
+		}
+	}
+	return entries
+}
+
+// LeafNodes returns nodes with no outgoing edges, in insertion order.
+func (g *Graph[K]) LeafNodes() []K {
+	var leaves []K
+	for _, n := range g.nodes {
+		if len(g.adj[n]) == 0 {
+			leaves = append(leaves, n)
+		}
+	}
+	return leaves
+}
+
+// TopologicalSort returns nodes in topological order using Kahn's algorithm.
+// When multiple nodes have in-degree 0, insertion order is used as the
+// tie-breaker for deterministic output. Returns an error if the graph
+// contains a cycle.
+func (g *Graph[K]) TopologicalSort() ([]K, error) {
+	if len(g.nodes) == 0 {
+		return nil, nil
+	}
+
+	// Compute in-degrees.
+	inDeg := make(map[K]int, len(g.nodes))
+	for _, n := range g.nodes {
+		inDeg[n] = len(g.inAdj[n])
+	}
+
+	// Seed the queue with all zero-in-degree nodes in insertion order.
+	var queue []K
+	for _, n := range g.nodes {
+		if inDeg[n] == 0 {
+			queue = append(queue, n)
+		}
+	}
+
+	// Index each node by its insertion position so we can sort successors
+	// by insertion order when they become ready.
+	pos := make(map[K]int, len(g.nodes))
+	for i, n := range g.nodes {
+		pos[n] = i
+	}
+
+	var result []K
+	for len(queue) > 0 {
+		// Pop front.
+		node := queue[0]
+		queue = queue[1:]
+		result = append(result, node)
+
+		// For each successor, decrement in-degree. If it reaches 0, insert
+		// into queue at the correct position to maintain insertion order.
+		for _, succ := range g.adj[node] {
+			inDeg[succ]--
+			if inDeg[succ] == 0 {
+				// Insert into queue maintaining insertion-order sort.
+				inserted := false
+				for i, q := range queue {
+					if pos[succ] < pos[q] {
+						queue = append(queue[:i+1], queue[i:]...)
+						queue[i] = succ
+						inserted = true
+						break
+					}
+				}
+				if !inserted {
+					queue = append(queue, succ)
+				}
+			}
+		}
+	}
+
+	if len(result) != len(g.nodes) {
+		return nil, fmt.Errorf("graph contains a cycle (%d nodes in cycle)", len(g.nodes)-len(result))
+	}
+
+	return result, nil
+}
+
+// HasCycle returns true if the graph contains at least one cycle.
+func (g *Graph[K]) HasCycle() bool {
+	_, err := g.TopologicalSort()
+	return err != nil
+}
+
+// Reachable returns all nodes reachable from the given node via BFS,
+// excluding the start node itself. Returns nodes in BFS discovery order.
+// Returns nil if the node doesn't exist or has no reachable nodes.
+func (g *Graph[K]) Reachable(from K) []K {
+	if !g.seen[from] {
+		return nil
+	}
+
+	visited := map[K]bool{from: true}
+	queue := []K{from}
+	var result []K
+
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+		for _, succ := range g.adj[node] {
+			if !visited[succ] {
+				visited[succ] = true
+				result = append(result, succ)
+				queue = append(queue, succ)
+			}
+		}
+	}
+
+	return result
+}

--- a/compiler/graph/graph_test.go
+++ b/compiler/graph/graph_test.go
@@ -1,0 +1,582 @@
+package graph_test
+
+import (
+	"testing"
+
+	"github.com/thakee/orca/compiler/graph"
+)
+
+// TestAddNode verifies node insertion, deduplication, and ordering.
+func TestAddNode(t *testing.T) {
+	tests := []struct {
+		name     string
+		add      []string
+		expected []string
+	}{
+		{
+			name:     "empty graph",
+			add:      nil,
+			expected: nil,
+		},
+		{
+			name:     "single node",
+			add:      []string{"a"},
+			expected: []string{"a"},
+		},
+		{
+			name:     "multiple nodes preserve insertion order",
+			add:      []string{"c", "a", "b"},
+			expected: []string{"c", "a", "b"},
+		},
+		{
+			name:     "duplicate nodes are ignored",
+			add:      []string{"a", "b", "a", "c", "b"},
+			expected: []string{"a", "b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, n := range tt.add {
+				g.AddNode(n)
+			}
+			got := g.Nodes()
+			assertSliceEqual(t, got, tt.expected)
+		})
+	}
+}
+
+// TestHasNode checks node existence queries.
+func TestHasNode(t *testing.T) {
+	tests := []struct {
+		name   string
+		add    []string
+		query  string
+		expect bool
+	}{
+		{
+			name:   "node exists",
+			add:    []string{"a", "b"},
+			query:  "a",
+			expect: true,
+		},
+		{
+			name:   "node does not exist",
+			add:    []string{"a", "b"},
+			query:  "c",
+			expect: false,
+		},
+		{
+			name:   "empty graph",
+			add:    nil,
+			query:  "a",
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, n := range tt.add {
+				g.AddNode(n)
+			}
+			if got := g.HasNode(tt.query); got != tt.expect {
+				t.Errorf("HasNode(%q) = %v, want %v", tt.query, got, tt.expect)
+			}
+		})
+	}
+}
+
+// TestAddEdge verifies edge insertion and implicit node creation.
+func TestAddEdge(t *testing.T) {
+	tests := []struct {
+		name          string
+		edges         [][2]string
+		expectedNodes []string
+		expectedEdges []graph.Edge[string]
+	}{
+		{
+			name:          "single edge creates both nodes",
+			edges:         [][2]string{{"a", "b"}},
+			expectedNodes: []string{"a", "b"},
+			expectedEdges: []graph.Edge[string]{{From: "a", To: "b"}},
+		},
+		{
+			name:          "duplicate edges are ignored",
+			edges:         [][2]string{{"a", "b"}, {"a", "b"}},
+			expectedNodes: []string{"a", "b"},
+			expectedEdges: []graph.Edge[string]{{From: "a", To: "b"}},
+		},
+		{
+			name:          "chain A->B->C",
+			edges:         [][2]string{{"a", "b"}, {"b", "c"}},
+			expectedNodes: []string{"a", "b", "c"},
+			expectedEdges: []graph.Edge[string]{{From: "a", To: "b"}, {From: "b", To: "c"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, e := range tt.edges {
+				g.AddEdge(e[0], e[1])
+			}
+			assertSliceEqual(t, g.Nodes(), tt.expectedNodes)
+			gotEdges := g.Edges()
+			if len(gotEdges) != len(tt.expectedEdges) {
+				t.Fatalf("Edges() len = %d, want %d", len(gotEdges), len(tt.expectedEdges))
+			}
+			for i, e := range gotEdges {
+				if e != tt.expectedEdges[i] {
+					t.Errorf("Edges()[%d] = %v, want %v", i, e, tt.expectedEdges[i])
+				}
+			}
+		})
+	}
+}
+
+// TestHasEdge checks edge existence queries.
+func TestHasEdge(t *testing.T) {
+	tests := []struct {
+		name   string
+		edges  [][2]string
+		from   string
+		to     string
+		expect bool
+	}{
+		{
+			name:   "edge exists",
+			edges:  [][2]string{{"a", "b"}},
+			from:   "a",
+			to:     "b",
+			expect: true,
+		},
+		{
+			name:   "reverse edge does not exist",
+			edges:  [][2]string{{"a", "b"}},
+			from:   "b",
+			to:     "a",
+			expect: false,
+		},
+		{
+			name:   "no edges",
+			edges:  nil,
+			from:   "a",
+			to:     "b",
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, e := range tt.edges {
+				g.AddEdge(e[0], e[1])
+			}
+			if got := g.HasEdge(tt.from, tt.to); got != tt.expect {
+				t.Errorf("HasEdge(%q, %q) = %v, want %v", tt.from, tt.to, got, tt.expect)
+			}
+		})
+	}
+}
+
+// TestSuccessors checks outgoing neighbor queries.
+func TestSuccessors(t *testing.T) {
+	tests := []struct {
+		name     string
+		edges    [][2]string
+		query    string
+		expected []string
+	}{
+		{
+			name:     "node with successors",
+			edges:    [][2]string{{"a", "b"}, {"a", "c"}},
+			query:    "a",
+			expected: []string{"b", "c"},
+		},
+		{
+			name:     "leaf node",
+			edges:    [][2]string{{"a", "b"}},
+			query:    "b",
+			expected: nil,
+		},
+		{
+			name:     "nonexistent node",
+			edges:    [][2]string{{"a", "b"}},
+			query:    "z",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, e := range tt.edges {
+				g.AddEdge(e[0], e[1])
+			}
+			assertSliceEqual(t, g.Successors(tt.query), tt.expected)
+		})
+	}
+}
+
+// TestPredecessors checks incoming neighbor queries.
+func TestPredecessors(t *testing.T) {
+	tests := []struct {
+		name     string
+		edges    [][2]string
+		query    string
+		expected []string
+	}{
+		{
+			name:     "node with predecessors",
+			edges:    [][2]string{{"a", "c"}, {"b", "c"}},
+			query:    "c",
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "entry node",
+			edges:    [][2]string{{"a", "b"}},
+			query:    "a",
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, e := range tt.edges {
+				g.AddEdge(e[0], e[1])
+			}
+			assertSliceEqual(t, g.Predecessors(tt.query), tt.expected)
+		})
+	}
+}
+
+// TestEntryNodes checks nodes with no incoming edges.
+func TestEntryNodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodes    []string
+		edges    [][2]string
+		expected []string
+	}{
+		{
+			name:     "empty graph",
+			expected: nil,
+		},
+		{
+			name:     "single node no edges",
+			nodes:    []string{"a"},
+			expected: []string{"a"},
+		},
+		{
+			name:     "linear chain",
+			edges:    [][2]string{{"a", "b"}, {"b", "c"}},
+			expected: []string{"a"},
+		},
+		{
+			name:     "diamond",
+			edges:    [][2]string{{"a", "b"}, {"a", "c"}, {"b", "d"}, {"c", "d"}},
+			expected: []string{"a"},
+		},
+		{
+			name:     "multiple entry nodes",
+			edges:    [][2]string{{"a", "c"}, {"b", "c"}},
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "disconnected components",
+			edges:    [][2]string{{"a", "b"}, {"c", "d"}},
+			expected: []string{"a", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, n := range tt.nodes {
+				g.AddNode(n)
+			}
+			for _, e := range tt.edges {
+				g.AddEdge(e[0], e[1])
+			}
+			assertSliceEqual(t, g.EntryNodes(), tt.expected)
+		})
+	}
+}
+
+// TestLeafNodes checks nodes with no outgoing edges.
+func TestLeafNodes(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodes    []string
+		edges    [][2]string
+		expected []string
+	}{
+		{
+			name:     "empty graph",
+			expected: nil,
+		},
+		{
+			name:     "single node no edges",
+			nodes:    []string{"a"},
+			expected: []string{"a"},
+		},
+		{
+			name:     "linear chain",
+			edges:    [][2]string{{"a", "b"}, {"b", "c"}},
+			expected: []string{"c"},
+		},
+		{
+			name:     "multiple leaf nodes",
+			edges:    [][2]string{{"a", "b"}, {"a", "c"}},
+			expected: []string{"b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, n := range tt.nodes {
+				g.AddNode(n)
+			}
+			for _, e := range tt.edges {
+				g.AddEdge(e[0], e[1])
+			}
+			assertSliceEqual(t, g.LeafNodes(), tt.expected)
+		})
+	}
+}
+
+// TestTopologicalSort verifies Kahn's algorithm for valid DAGs.
+func TestTopologicalSort(t *testing.T) {
+	tests := []struct {
+		name     string
+		nodes    []string
+		edges    [][2]string
+		expected []string
+	}{
+		{
+			name:     "empty graph",
+			expected: nil,
+		},
+		{
+			name:     "single node",
+			nodes:    []string{"a"},
+			expected: []string{"a"},
+		},
+		{
+			name:     "linear chain",
+			edges:    [][2]string{{"a", "b"}, {"b", "c"}},
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "diamond",
+			edges:    [][2]string{{"a", "b"}, {"a", "c"}, {"b", "d"}, {"c", "d"}},
+			expected: []string{"a", "b", "c", "d"},
+		},
+		{
+			name:     "disconnected components preserve insertion order",
+			edges:    [][2]string{{"x", "y"}, {"a", "b"}},
+			expected: []string{"x", "y", "a", "b"},
+		},
+		{
+			name:     "independent nodes preserve insertion order",
+			nodes:    []string{"c", "a", "b"},
+			expected: []string{"c", "a", "b"},
+		},
+		{
+			name:     "complex DAG",
+			edges:    [][2]string{{"a", "c"}, {"b", "c"}, {"c", "d"}, {"b", "d"}},
+			expected: []string{"a", "b", "c", "d"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, n := range tt.nodes {
+				g.AddNode(n)
+			}
+			for _, e := range tt.edges {
+				g.AddEdge(e[0], e[1])
+			}
+			got, err := g.TopologicalSort()
+			if err != nil {
+				t.Fatalf("TopologicalSort() unexpected error: %v", err)
+			}
+			assertSliceEqual(t, got, tt.expected)
+		})
+	}
+}
+
+// TestTopologicalSortCycleError verifies that cycles produce errors.
+func TestTopologicalSortCycleError(t *testing.T) {
+	tests := []struct {
+		name  string
+		edges [][2]string
+	}{
+		{
+			name:  "simple cycle A->B->A",
+			edges: [][2]string{{"a", "b"}, {"b", "a"}},
+		},
+		{
+			name:  "self loop",
+			edges: [][2]string{{"a", "a"}},
+		},
+		{
+			name:  "three node cycle",
+			edges: [][2]string{{"a", "b"}, {"b", "c"}, {"c", "a"}},
+		},
+		{
+			name:  "cycle with tail",
+			edges: [][2]string{{"x", "a"}, {"a", "b"}, {"b", "a"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, e := range tt.edges {
+				g.AddEdge(e[0], e[1])
+			}
+			_, err := g.TopologicalSort()
+			if err == nil {
+				t.Fatal("TopologicalSort() expected error for cyclic graph, got nil")
+			}
+		})
+	}
+}
+
+// TestHasCycle checks cycle detection.
+func TestHasCycle(t *testing.T) {
+	tests := []struct {
+		name   string
+		edges  [][2]string
+		expect bool
+	}{
+		{
+			name:   "no cycle",
+			edges:  [][2]string{{"a", "b"}, {"b", "c"}},
+			expect: false,
+		},
+		{
+			name:   "cycle",
+			edges:  [][2]string{{"a", "b"}, {"b", "a"}},
+			expect: true,
+		},
+		{
+			name:   "self loop",
+			edges:  [][2]string{{"a", "a"}},
+			expect: true,
+		},
+		{
+			name:   "empty graph",
+			expect: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, e := range tt.edges {
+				g.AddEdge(e[0], e[1])
+			}
+			if got := g.HasCycle(); got != tt.expect {
+				t.Errorf("HasCycle() = %v, want %v", got, tt.expect)
+			}
+		})
+	}
+}
+
+// TestReachable checks BFS reachability.
+func TestReachable(t *testing.T) {
+	tests := []struct {
+		name     string
+		edges    [][2]string
+		from     string
+		expected []string
+	}{
+		{
+			name:     "linear chain from start",
+			edges:    [][2]string{{"a", "b"}, {"b", "c"}},
+			from:     "a",
+			expected: []string{"b", "c"},
+		},
+		{
+			name:     "linear chain from middle",
+			edges:    [][2]string{{"a", "b"}, {"b", "c"}},
+			from:     "b",
+			expected: []string{"c"},
+		},
+		{
+			name:     "leaf node reaches nothing",
+			edges:    [][2]string{{"a", "b"}},
+			from:     "b",
+			expected: nil,
+		},
+		{
+			name:     "diamond from top",
+			edges:    [][2]string{{"a", "b"}, {"a", "c"}, {"b", "d"}, {"c", "d"}},
+			from:     "a",
+			expected: []string{"b", "c", "d"},
+		},
+		{
+			name:     "nonexistent node",
+			edges:    [][2]string{{"a", "b"}},
+			from:     "z",
+			expected: nil,
+		},
+		{
+			name:     "cycle reachability",
+			edges:    [][2]string{{"a", "b"}, {"b", "c"}, {"c", "a"}},
+			from:     "a",
+			expected: []string{"b", "c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := graph.New[string]()
+			for _, e := range tt.edges {
+				g.AddEdge(e[0], e[1])
+			}
+			assertSliceEqual(t, g.Reachable(tt.from), tt.expected)
+		})
+	}
+}
+
+// TestIntegerNodes verifies the generic type parameter works with int keys.
+func TestIntegerNodes(t *testing.T) {
+	g := graph.New[int]()
+	g.AddEdge(1, 2)
+	g.AddEdge(2, 3)
+
+	got, err := g.TopologicalSort()
+	if err != nil {
+		t.Fatalf("TopologicalSort() unexpected error: %v", err)
+	}
+	expected := []int{1, 2, 3}
+	if len(got) != len(expected) {
+		t.Fatalf("got %v, want %v", got, expected)
+	}
+	for i := range got {
+		if got[i] != expected[i] {
+			t.Errorf("got[%d] = %v, want %v", i, got[i], expected[i])
+		}
+	}
+}
+
+// assertSliceEqual compares two slices for equality.
+func assertSliceEqual[T comparable](t *testing.T, got, expected []T) {
+	t.Helper()
+	if len(got) != len(expected) {
+		t.Fatalf("got %v (len %d), want %v (len %d)", got, len(got), expected, len(expected))
+	}
+	for i := range got {
+		if got[i] != expected[i] {
+			t.Errorf("index %d: got %v, want %v", i, got[i], expected[i])
+		}
+	}
+}

--- a/compiler/types/types.go
+++ b/compiler/types/types.go
@@ -219,6 +219,12 @@ func IsCompatible(got Type, expected Type) bool {
 			return true
 		}
 
+		// When got is an instance block (e.g. `model o {}`), check if its
+		// schema matches expected (e.g. `schema model {}`).
+		if got.Block.Schema != nil && got.Block.Schema == expected.Block {
+			return true
+		}
+
 		return false
 	}
 

--- a/compiler/workflow/workflow.go
+++ b/compiler/workflow/workflow.go
@@ -5,6 +5,7 @@ package workflow
 
 import (
 	"github.com/thakee/orca/compiler/ast"
+	"github.com/thakee/orca/compiler/graph"
 	"github.com/thakee/orca/compiler/token"
 )
 
@@ -80,58 +81,53 @@ func Resolve(block *ast.BlockStatement, isTrigger func(string) bool) ResolvedWor
 		TriggerMap: make(map[string][]string),
 	}
 
-	// Collect all unique edges and nodes from arrow expressions.
-	var allEdges []Edge
-	seenEdges := make(map[[2]string]bool)
-	seenNodes := make(map[string]bool)
+	// Build a graph of all nodes and edges from arrow expressions.
+	// Triggers are tracked separately and excluded from the processing graph.
+	allGraph := graph.New[string]()
 	triggers := make(map[string]bool)
+
+	// classifyNode registers a node as either a trigger or processing node.
+	classifyNode := func(name string) {
+		if isTrigger(name) {
+			if !triggers[name] {
+				triggers[name] = true
+				rw.Triggers = append(rw.Triggers, name)
+			}
+		}
+		allGraph.AddNode(name)
+	}
 
 	for _, expr := range block.Expressions {
 		edges := EdgesFromExpr(expr)
 		if len(edges) == 0 {
 			// Standalone identifier (no arrows) — treat as a single node.
-			if name := ExprToNodeName(expr); name != "" && !seenNodes[name] {
-				seenNodes[name] = true
-				if isTrigger(name) {
-					triggers[name] = true
-					rw.Triggers = append(rw.Triggers, name)
-				} else {
-					rw.Nodes = append(rw.Nodes, name)
-				}
+			if name := ExprToNodeName(expr); name != "" {
+				classifyNode(name)
 			}
 			continue
 		}
-
 		for _, e := range edges {
-			edgeKey := [2]string{e.From, e.To}
-			if seenEdges[edgeKey] {
-				continue
-			}
-			seenEdges[edgeKey] = true
-			allEdges = append(allEdges, e)
+			classifyNode(e.From)
+			classifyNode(e.To)
+			allGraph.AddEdge(e.From, e.To)
+		}
+	}
 
-			for _, name := range []string{e.From, e.To} {
-				if !seenNodes[name] {
-					seenNodes[name] = true
-					if isTrigger(name) {
-						triggers[name] = true
-						rw.Triggers = append(rw.Triggers, name)
-					} else {
-						rw.Nodes = append(rw.Nodes, name)
-					}
-				}
-			}
+	// Separate triggers from processing nodes (preserving insertion order).
+	procGraph := graph.New[string]()
+	for _, name := range allGraph.Nodes() {
+		if !triggers[name] {
+			rw.Nodes = append(rw.Nodes, name)
+			procGraph.AddNode(name)
 		}
 	}
 
 	// Separate trigger edges from processing edges and build TriggerMap.
-	var processingEdges []Edge
-	for _, e := range allEdges {
+	for _, e := range allGraph.Edges() {
 		if triggers[e.From] {
-			// Trigger → processing node: record in TriggerMap.
 			rw.TriggerMap[e.From] = append(rw.TriggerMap[e.From], e.To)
 		} else {
-			processingEdges = append(processingEdges, e)
+			procGraph.AddEdge(e.From, e.To)
 		}
 	}
 
@@ -143,41 +139,18 @@ func Resolve(block *ast.BlockStatement, isTrigger func(string) bool) ResolvedWor
 		}
 	}
 
-	// Infer END edges for processing nodes with no outgoing edges.
-	rw.Edges = inferEndEdges(rw.Nodes, processingEdges)
+	// Infer END edges for leaf processing nodes (no outgoing edges).
+	for _, e := range procGraph.Edges() {
+		rw.Edges = append(rw.Edges, Edge{From: e.From, To: e.To})
+	}
+	for _, leaf := range procGraph.LeafNodes() {
+		rw.Edges = append(rw.Edges, Edge{From: leaf, To: NodeEND})
+	}
 
-	// Compute entry nodes: processing nodes with no incoming edges
-	// from other processing nodes.
-	hasIncoming := make(map[string]bool)
-	for _, e := range processingEdges {
-		hasIncoming[e.To] = true
-	}
-	for _, node := range rw.Nodes {
-		if !hasIncoming[node] {
-			rw.EntryNodes = append(rw.EntryNodes, node)
-		}
-	}
+	// Entry nodes: processing nodes with no incoming edges.
+	rw.EntryNodes = procGraph.EntryNodes()
 
 	return rw
-}
-
-// inferEndEdges appends implicit END edges for processing nodes that have
-// no outgoing edges. START edges are never added — the router handles them.
-func inferEndEdges(nodes []string, edges []Edge) []Edge {
-	hasOutgoing := make(map[string]bool)
-	for _, e := range edges {
-		hasOutgoing[e.From] = true
-	}
-
-	result := make([]Edge, len(edges))
-	copy(result, edges)
-
-	for _, node := range nodes {
-		if !hasOutgoing[node] {
-			result = append(result, Edge{From: node, To: NodeEND})
-		}
-	}
-	return result
 }
 
 // EdgesFromExpr walks a (possibly chained) arrow expression and returns


### PR DESCRIPTION
## Summary

- Add `compiler/graph` as a shared directed graph (topological sort, entry/leaf nodes, reachability) for analyzer and workflow code.
- Extend type compatibility so block instances match their schema type where appropriate.
- Analyzer builds a block dependency graph from cross-block references in block bodies, topologically sorts it into `AnalyzedProgram.BlockOrder`, and reports `cyclic-dependency` on cycles. LangGraph codegen emits user blocks in that order and drops per-kind `# --- ... ---` section banners; goldens updated.
- `BaseBackend.BlockByName` supports ordered emission.
- Workflow `Resolve` now constructs trigger vs processing subgraphs using `graph.Graph` instead of ad-hoc maps; END edges from leaf nodes; entry nodes via graph helpers.

## Testing

- `go test ./...` from `compiler/`

Made with [Cursor](https://cursor.com)