### PR TITLE
🧠 Improve const folding and LangGraph expression codegen

### DIFF
--- a/compiler/analyzer/analyzer.go
+++ b/compiler/analyzer/analyzer.go
@@ -23,6 +23,10 @@ type AnalyzedProgram struct {
 	// Blocks with no dependencies come first; dependents come after their
 	// dependencies. Codegen uses this to emit blocks in valid definition order.
 	BlockOrder []string
+
+	// ConstFoldCache is a cache of constant fold results for expressions.
+	// This is used to avoid redundant constant folding calculations.
+	ConstFoldCache map[ast.Expression]ConstValue
 }
 
 // Analyze walks the AST and performs semantic analysis.
@@ -36,15 +40,17 @@ func Analyze(program *ast.Program) AnalyzedProgram {
 	bootstrapResult := types.Bootstrap(types.BootstrapSource)
 
 	ap := AnalyzedProgram{
-		Ast:         program,
-		SymbolTable: bootstrapResult.Symtab,
-		Diagnostics: []diagnostic.Diagnostic{},
+		Ast:            program,
+		SymbolTable:    bootstrapResult.Symtab,
+		Diagnostics:    []diagnostic.Diagnostic{},
+		ConstFoldCache: make(map[ast.Expression]ConstValue),
 	}
 
 	// These function should run in this order
 	injectAnonBlocks(&ap)
 	buildSymbolTable(&ap)
 	resolveBlockSchemaReferences(&ap)
+	foldConstants(&ap)
 	buildBlockDependencyGraph(&ap)
 
 	for _, stmt := range program.Statements {
@@ -219,4 +225,14 @@ func filterSuppressed(diags []diagnostic.Diagnostic, codes map[string]bool, supp
 		}
 	}
 	return filtered
+}
+
+// foldConstants folds the constants in the AST.
+func foldConstants(ap *AnalyzedProgram) {
+	ast.Walk(ap.Ast, func(n ast.Node) bool {
+		if expr, ok := n.(ast.Expression); ok {
+			ConstFold(expr, ap)
+		}
+		return true
+	})
 }

--- a/compiler/analyzer/const_fold.go
+++ b/compiler/analyzer/const_fold.go
@@ -30,23 +30,59 @@ const (
 // ConstValue holds a single folded constant. Only the field that matches
 // Kind is defined; other fields are zero.
 type ConstValue struct {
-	Kind   ConstKind
+	Kind ConstKind
+	Expr ast.Expression
+
 	Str    string
 	Number float64
+	Bool   bool
 
-	List     []ConstValue
-	KeyValue map[string]ConstValue // Used for maps and blocks
-	Partial  bool                  // True if the constant is partial like contains unknown values.
+	// BlockKind is the original block kind name (e.g. "model", "agent") when
+	// Kind == ConstBlock. Empty for other kinds.
+	BlockKind string
+
+	Partial bool // True if the constant is partial like contains unknown values.
+	List    []ConstValue
+	// Note that we can't use a map[string]ConstValue for maps and blocks because
+	// Go map iteration is randomized, so when we codegen iterating the map the
+	// order is not deterministic, causing golden test flakiness, and unpredictable
+	// codegen output.
+	Keys   []string     // Map keys
+	Values []ConstValue // Map values
 }
 
 // ConstFold performs compile-time constant folding on an expression.
 // A zero AnalyzedProgram (nil Symbols and nil AST) folds literals and
 // structure only; identifier resolution and block refs need Symbols and AST.
 // Returns the folded constant value and any diagnostics.
-func ConstFold(expr ast.Expression, ap AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
+func ConstFold(expr ast.Expression, ap *AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
+
+	// If we have cache
+	if ap != nil && ap.ConstFoldCache != nil {
+		if cached, ok := ap.ConstFoldCache[expr]; ok {
+			return cached, nil
+		}
+
+		// Cache a sentinel to break cyclic reference cause infinite recursion.
+		ap.ConstFoldCache[expr] = ConstValue{Kind: ConstUnknown, Partial: true, Expr: expr}
+
+		constVal, diags := constFold(expr, ap)
+		constVal.Expr = expr
+		ap.ConstFoldCache[expr] = constVal
+
+		return constVal, diags
+	}
+
+	// We dont have a cache, just fold the expression.
+	constVal, diags := constFold(expr, ap)
+	constVal.Expr = expr
+	return constVal, diags
+}
+
+func constFold(expr ast.Expression, ap *AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
 
 	if expr == nil {
-		return ConstValue{}, nil
+		return ConstValue{Kind: ConstUnknown, Partial: true}, nil
 	}
 	var diags []diagnostic.Diagnostic
 	switch e := expr.(type) {
@@ -84,9 +120,10 @@ func ConstFold(expr ast.Expression, ap AnalyzedProgram) (ConstValue, []diagnosti
 
 // foldMapLiteral builds ConstMap when every entry key is a foldable map key
 // (string, identifier, or integer literal) and every value folds to a constant.
-func foldMapLiteral(ml *ast.MapLiteral, ap AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
+func foldMapLiteral(ml *ast.MapLiteral, ap *AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
 	var diags []diagnostic.Diagnostic
-	out := make(map[string]ConstValue, len(ml.Entries))
+	keys := make([]string, 0, len(ml.Entries))
+	values := make([]ConstValue, 0, len(ml.Entries))
 	partial := false
 	for _, ent := range ml.Entries {
 		keyValue, dK := ConstFold(ent.Key, ap)
@@ -107,13 +144,14 @@ func foldMapLiteral(ml *ast.MapLiteral, ap AnalyzedProgram) (ConstValue, []diagn
 				Source:      "analyzer",
 			})
 		}
-		out[keyValue.Str] = valueValue
+		keys = append(keys, keyValue.Str)
+		values = append(values, valueValue)
 	}
-	return ConstValue{Kind: ConstMap, KeyValue: out, Partial: partial}, diags
+	return ConstValue{Kind: ConstMap, Keys: keys, Values: values, Partial: partial}, diags
 }
 
 // foldListLiteral builds ConstList when every element folds to a constant.
-func foldListLiteral(ll *ast.ListLiteral, ap AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
+func foldListLiteral(ll *ast.ListLiteral, ap *AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
 	var diags []diagnostic.Diagnostic
 	if len(ll.Elements) == 0 {
 		return ConstValue{Kind: ConstList, List: []ConstValue{}}, diags
@@ -133,12 +171,13 @@ func foldListLiteral(ll *ast.ListLiteral, ap AnalyzedProgram) (ConstValue, []dia
 
 // foldBlockBody builds ConstBlock when the block body has no workflow edge
 // expressions and every assignment value folds to a constant.
-func foldBlockBody(body *ast.BlockBody, ap AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
+func foldBlockBody(body *ast.BlockBody, ap *AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
 	var diags []diagnostic.Diagnostic
 	if len(body.Expressions) > 0 {
-		return ConstValue{Kind: ConstBlock, Partial: true}, diags
+		return ConstValue{Kind: ConstBlock, BlockKind: body.Kind, Partial: true}, diags
 	}
-	out := make(map[string]ConstValue, len(body.Assignments))
+	keys := make([]string, 0, len(body.Assignments))
+	values := make([]ConstValue, 0, len(body.Assignments))
 	partial := false
 	for _, a := range body.Assignments {
 		if a == nil {
@@ -149,14 +188,15 @@ func foldBlockBody(body *ast.BlockBody, ap AnalyzedProgram) (ConstValue, []diagn
 		if v.Kind == ConstUnknown {
 			partial = true
 		}
-		out[a.Name] = v
+		keys = append(keys, a.Name)
+		values = append(values, v)
 	}
-	return ConstValue{Kind: ConstBlock, KeyValue: out, Partial: partial}, diags
+	return ConstValue{Kind: ConstBlock, BlockKind: body.Kind, Keys: keys, Values: values, Partial: partial}, diags
 }
 
 // foldBinary folds + - * / on numeric constants, string concatenation for +,
 // and leaves workflow operators (->, |) and other cases as unknown.
-func foldBinary(e *ast.BinaryExpression, ap AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
+func foldBinary(e *ast.BinaryExpression, ap *AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
 	left, d1 := ConstFold(e.Left, ap)
 	right, d2 := ConstFold(e.Right, ap)
 	diags := append(d1, d2...)
@@ -233,12 +273,21 @@ func constAsNumber(v ConstValue) (float64, bool) {
 
 // foldIdentifier folds named blocks (including let blocks) by re-folding
 // their body. Symbols without a matching block yield ConstUnknown.
-func foldIdentifier(e *ast.Identifier, ap AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
+func foldIdentifier(e *ast.Identifier, ap *AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
 	// Parsed as an identifier; does not require symbol resolution for folding.
 	if e.Value == types.BlockKindNull {
 		return ConstValue{Kind: ConstNull}, nil
 	}
-	if ap.SymbolTable == nil {
+
+	// true and false
+	if e.Value == types.BuiltinIdentifierTrue {
+		return ConstValue{Kind: ConstBool, Bool: true}, nil
+	}
+	if e.Value == types.BuiltinIdentifierFalse {
+		return ConstValue{Kind: ConstBool, Bool: false}, nil
+	}
+
+	if ap == nil || ap.SymbolTable == nil {
 		return ConstValue{Kind: ConstUnknown}, nil
 	}
 	sym, ok := ap.SymbolTable.LookupSymbol(e.Value)
@@ -259,10 +308,19 @@ func foldIdentifier(e *ast.Identifier, ap AnalyzedProgram) (ConstValue, []diagno
 	}
 }
 
+func findMemberInConstKeyValue(block ConstValue, member string) (ConstValue, bool) {
+	for i, key := range block.Keys {
+		if key == member {
+			return block.Values[i], true
+		}
+	}
+	return ConstValue{Kind: ConstUnknown}, false
+}
+
 // foldMemberAccess folds object.member when the object is a constant block-shaped
 // value (ConstBlock). Primitives, maps, null, lists, and unknown shapes return
 // ConstUnknown (no constant member projection for those yet).
-func foldMemberAccess(e *ast.MemberAccess, ap AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
+func foldMemberAccess(e *ast.MemberAccess, ap *AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
 	var diags []diagnostic.Diagnostic
 	left, d1 := ConstFold(e.Object, ap)
 	diags = append(diags, d1...)
@@ -284,7 +342,7 @@ func foldMemberAccess(e *ast.MemberAccess, ap AnalyzedProgram) (ConstValue, []di
 		return ConstValue{Kind: ConstUnknown}, diags
 
 	case ConstBlock:
-		value, ok := left.KeyValue[e.Member]
+		value, ok := findMemberInConstKeyValue(left, e.Member)
 		if !ok {
 			memberStart, memberEnd := diagnostic.PositionOf(e.End()), diagnostic.EndPositionOf(e.End())
 			diags = append(diags, diagnostic.Diagnostic{
@@ -307,7 +365,7 @@ func foldMemberAccess(e *ast.MemberAccess, ap AnalyzedProgram) (ConstValue, []di
 // foldSubscription returns map[key] for a constant map with string key, or list[i]
 // for a constant list with integer index in range. Other shapes or non-constant
 // object/index fold to ConstUnknown.
-func foldSubscription(e *ast.Subscription, ap AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
+func foldSubscription(e *ast.Subscription, ap *AnalyzedProgram) (ConstValue, []diagnostic.Diagnostic) {
 	left, d1 := ConstFold(e.Object, ap)
 	// Const folding only supports single-index subscriptions (list[i], map[k]).
 	if len(e.Indices) != 1 {
@@ -335,7 +393,7 @@ func foldSubscription(e *ast.Subscription, ap AnalyzedProgram) (ConstValue, []di
 			})
 			return ConstValue{Kind: ConstUnknown}, diags
 		}
-		value, ok := left.KeyValue[index.Str]
+		value, ok := findMemberInConstKeyValue(left, index.Str)
 		if !ok {
 			diags = append(diags, diagnostic.Diagnostic{
 				Severity:    diagnostic.Error,

--- a/compiler/analyzer/const_fold_test.go
+++ b/compiler/analyzer/const_fold_test.go
@@ -1,7 +1,6 @@
 package analyzer
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/thakee/orca/compiler/ast"
@@ -36,11 +35,21 @@ func TestConstFoldLiterals(t *testing.T) {
 			expr: &ast.Identifier{BaseNode: ast.NewTerminal(token.Token{Type: token.IDENT, Literal: "null"}), Value: types.BlockKindNull},
 			want: ConstValue{Kind: ConstNull},
 		},
+		{
+			name: "bool true",
+			expr: &ast.Identifier{BaseNode: ast.NewTerminal(token.Token{Type: token.IDENT, Literal: "true"}), Value: types.BuiltinIdentifierTrue},
+			want: ConstValue{Kind: ConstBool, Bool: true},
+		},
+		{
+			name: "bool false",
+			expr: &ast.Identifier{BaseNode: ast.NewTerminal(token.Token{Type: token.IDENT, Literal: "false"}), Value: types.BuiltinIdentifierFalse},
+			want: ConstValue{Kind: ConstBool, Bool: false},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, diags := ConstFold(tt.expr, AnalyzedProgram{})
-			if !reflect.DeepEqual(got, tt.want) {
+			got, diags := ConstFold(tt.expr, nil)
+			if !constValueEqual(got, tt.want) {
 				t.Errorf("ConstFold() = %#v, want %#v", got, tt.want)
 			}
 			if len(diags) != 0 {
@@ -85,7 +94,7 @@ func TestConstFoldListAndMap(t *testing.T) {
 		{
 			name: "empty map",
 			expr: &ast.MapLiteral{Entries: []ast.MapEntry{}},
-			want: ConstValue{Kind: ConstMap, KeyValue: map[string]ConstValue{}},
+			want: ConstValue{Kind: ConstMap},
 		},
 		{
 			name: "map string keys",
@@ -93,10 +102,11 @@ func TestConstFoldListAndMap(t *testing.T) {
 				{Key: str("a"), Value: i(1)},
 				{Key: str("b"), Value: str("z")},
 			}},
-			want: ConstValue{Kind: ConstMap, KeyValue: map[string]ConstValue{
-				"a": {Kind: ConstNumber, Number: 1},
-				"b": {Kind: ConstString, Str: "z"},
-			}},
+			want: ConstValue{
+				Kind:   ConstMap,
+				Keys:   []string{"a", "b"},
+				Values: []ConstValue{{Kind: ConstNumber, Number: 1}, {Kind: ConstString, Str: "z"}},
+			},
 		},
 		{
 			name: "map identifier keys",
@@ -104,7 +114,12 @@ func TestConstFoldListAndMap(t *testing.T) {
 				{Key: id("k"), Value: i(7)},
 			}},
 			// Identifier keys are not ConstString; storage uses keyValue.Str (empty for non-string kinds).
-			want: ConstValue{Kind: ConstMap, KeyValue: map[string]ConstValue{"": {Kind: ConstNumber, Number: 7}}, Partial: true},
+			want: ConstValue{
+				Kind:    ConstMap,
+				Keys:    []string{""},
+				Values:  []ConstValue{{Kind: ConstNumber, Number: 7}},
+				Partial: true,
+			},
 		},
 		{
 			name: "map int key",
@@ -112,13 +127,17 @@ func TestConstFoldListAndMap(t *testing.T) {
 				{Key: i(10), Value: str("ten")},
 			}},
 			// Integer keys use the same map path; key string is only filled for ConstString keys.
-			want: ConstValue{Kind: ConstMap, KeyValue: map[string]ConstValue{"": {Kind: ConstString, Str: "ten"}}},
+			want: ConstValue{
+				Kind:   ConstMap,
+				Keys:   []string{""},
+				Values: []ConstValue{{Kind: ConstString, Str: "ten"}},
+			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := ConstFold(tt.expr, AnalyzedProgram{})
-			if !reflect.DeepEqual(got, tt.want) {
+			got, _ := ConstFold(tt.expr, nil)
+			if !constValueEqual(got, tt.want) {
 				t.Errorf("ConstFold() = %#v, want %#v", got, tt.want)
 			}
 		})
@@ -137,9 +156,14 @@ func TestConstFoldMapNonStringKeyDiagnostic(t *testing.T) {
 	expr := &ast.MapLiteral{Entries: []ast.MapEntry{
 		{Key: numKey, Value: str},
 	}}
-	got, diags := ConstFold(expr, AnalyzedProgram{})
+	got, diags := ConstFold(expr, nil)
 	// Non-string keys still produce ConstMap; the key is stored under keyValue.Str (empty for number).
-	if got.Kind != ConstMap || !reflect.DeepEqual(got.KeyValue, map[string]ConstValue{"": {Kind: ConstString, Str: "v"}}) {
+	wantMap := ConstValue{
+		Kind:   ConstMap,
+		Keys:   []string{""},
+		Values: []ConstValue{{Kind: ConstString, Str: "v"}},
+	}
+	if !constValueEqual(got, wantMap) {
 		t.Errorf("expected ConstMap with empty-string key, got %#v", got)
 	}
 	if len(diags) != 1 {
@@ -170,9 +194,12 @@ func TestConstFoldBlockExpression(t *testing.T) {
 					},
 				},
 			},
-			want: ConstValue{Kind: ConstBlock, KeyValue: map[string]ConstValue{
-				"provider": {Kind: ConstString, Str: "openai"},
-			}},
+			want: ConstValue{
+				Kind:      ConstBlock,
+				BlockKind: "model",
+				Keys:      []string{"provider"},
+				Values:    []ConstValue{{Kind: ConstString, Str: "openai"}},
+			},
 		},
 		{
 			name: "workflow edges not constant",
@@ -184,13 +211,13 @@ func TestConstFoldBlockExpression(t *testing.T) {
 				},
 			},
 			// Any non-empty Expressions marks the block as non-constant shape; result is ConstBlock with Partial.
-			want: ConstValue{Kind: ConstBlock, Partial: true},
+			want: ConstValue{Kind: ConstBlock, BlockKind: types.BlockKindWorkflow, Partial: true},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := ConstFold(tt.be, AnalyzedProgram{})
-			if !reflect.DeepEqual(got, tt.want) {
+			got, _ := ConstFold(tt.be, nil)
+			if !constValueEqual(got, tt.want) {
 				t.Errorf("ConstFold() = %#v, want %#v", got, tt.want)
 			}
 		})
@@ -324,8 +351,9 @@ func TestConstFoldMemberAccess(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, diags := ConstFold(tt.expr, AnalyzedProgram{Ast: tt.program, SymbolTable: tt.symbols})
-			if !reflect.DeepEqual(got, tt.want) {
+			ap := &AnalyzedProgram{Ast: tt.program, SymbolTable: tt.symbols, ConstFoldCache: map[ast.Expression]ConstValue{}}
+			got, diags := ConstFold(tt.expr, ap)
+			if !constValueEqual(got, tt.want) {
 				t.Errorf("ConstFold() = %#v, want %#v", got, tt.want)
 			}
 			assertConstFoldDiagCodes(t, diags, tt.expDiagCodes)
@@ -446,13 +474,60 @@ func TestConstFoldSubscription(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, diags := ConstFold(tt.expr, AnalyzedProgram{Ast: tt.program, SymbolTable: tt.symbols})
-			if !reflect.DeepEqual(got, tt.want) {
+			ap := &AnalyzedProgram{Ast: tt.program, SymbolTable: tt.symbols, ConstFoldCache: map[ast.Expression]ConstValue{}}
+			got, diags := ConstFold(tt.expr, ap)
+			if !constValueEqual(got, tt.want) {
 				t.Errorf("ConstFold() = %#v, want %#v", got, tt.want)
 			}
 			assertConstFoldDiagCodes(t, diags, tt.expDiagCodes)
 		})
 	}
+}
+
+// constValueEqual reports whether two ConstValues are semantically equal,
+// ignoring the Expr field at every level of the tree.
+//
+// We can't use reflect.DeepEqual directly: ConstFold now stores the source
+// ast.Expression on each ConstValue (and on every nested List element and
+// Keys/Values entry) so the emitter can fall back to the AST when a folded
+// child is ConstUnknown. That AST pointer is metadata for codegen, not part
+// of the fold's semantic output, and the hand-written `want` literals in
+// these tests leave Expr as nil. A direct DeepEqual therefore always fails
+// on the Expr mismatch even when the folded value is correct.
+//
+// Zeroing Expr on a copy before comparing is unsafe because ConstValue.List
+// and ConstValue.Values are reference types — mutating the copy would
+// corrupt the cache entry the caller still holds. Hence this recursive
+// walk, which compares every scalar field explicitly and skips Expr.
+func constValueEqual(a, b ConstValue) bool {
+	if a.Kind != b.Kind ||
+		a.Str != b.Str ||
+		a.Number != b.Number ||
+		a.Bool != b.Bool ||
+		a.BlockKind != b.BlockKind ||
+		a.Partial != b.Partial {
+		return false
+	}
+	if len(a.List) != len(b.List) {
+		return false
+	}
+	for i := range a.List {
+		if !constValueEqual(a.List[i], b.List[i]) {
+			return false
+		}
+	}
+	if len(a.Keys) != len(b.Keys) || len(a.Values) != len(b.Values) {
+		return false
+	}
+	for i := range a.Keys {
+		if a.Keys[i] != b.Keys[i] {
+			return false
+		}
+		if !constValueEqual(a.Values[i], b.Values[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 // assertConstFoldDiagCodes checks diagnostic codes when exp is nil (expect none) or a list of expected codes in order.
@@ -509,8 +584,8 @@ func TestConstFoldBinary(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, _ := ConstFold(tt.expr, AnalyzedProgram{})
-			if !reflect.DeepEqual(got, tt.want) {
+			got, _ := ConstFold(tt.expr, nil)
+			if !constValueEqual(got, tt.want) {
 				t.Errorf("ConstFold() = %#v, want %#v", got, tt.want)
 			}
 		})
@@ -630,9 +705,10 @@ func TestConstFoldIdentifier(t *testing.T) {
 			},
 			want: ConstValue{
 				Kind: ConstBlock,
-				KeyValue: map[string]ConstValue{
-					"provider":    {Kind: ConstString, Str: "openai"},
-					"temperature": {Kind: ConstNumber, Number: 0.5},
+				Keys: []string{"provider", "temperature"},
+				Values: []ConstValue{
+					{Kind: ConstString, Str: "openai"},
+					{Kind: ConstNumber, Number: 0.5},
 				},
 			},
 		},
@@ -662,8 +738,9 @@ func TestConstFoldIdentifier(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, diags := ConstFold(idExpr(tt.id), AnalyzedProgram{Ast: tt.program, SymbolTable: tt.symbols})
-			if !reflect.DeepEqual(got, tt.want) {
+			ap := &AnalyzedProgram{Ast: tt.program, SymbolTable: tt.symbols, ConstFoldCache: map[ast.Expression]ConstValue{}}
+			got, diags := ConstFold(idExpr(tt.id), ap)
+			if !constValueEqual(got, tt.want) {
 				t.Errorf("ConstFold() = %#v, want %#v", got, tt.want)
 			}
 			if len(diags) != 0 {
@@ -702,12 +779,96 @@ model gpt {
 	if !ok {
 		t.Fatal("provider field missing")
 	}
-	v, diags := ConstFold(expr, ap)
+	v, diags := ConstFold(expr, &ap)
 	if len(diags) != 0 {
 		t.Errorf("unexpected diags: %v", diags)
 	}
 	want := ConstValue{Kind: ConstString, Str: "openai"}
-	if !reflect.DeepEqual(v, want) {
+	if !constValueEqual(v, want) {
 		t.Errorf("ConstFold(provider) = %#v, want %#v", v, want)
 	}
+}
+
+// TestConstFoldCacheReuse verifies that ConstFold returns cached results on a
+// second call for the same expression without recomputing. We poison the cache
+// entry with a sentinel value after the first fold; the second fold must return
+// the poisoned value, proving it came from the cache rather than being re-walked.
+func TestConstFoldCacheReuse(t *testing.T) {
+	expr := &ast.NumberLiteral{
+		BaseNode: ast.NewTerminal(token.Token{Type: token.NUMBER, Literal: "42"}),
+		Value:    42,
+	}
+	ap := &AnalyzedProgram{ConstFoldCache: map[ast.Expression]ConstValue{}}
+
+	first, _ := ConstFold(expr, ap)
+	if !constValueEqual(first, ConstValue{Kind: ConstNumber, Number: 42}) {
+		t.Fatalf("first fold = %#v, want ConstNumber 42", first)
+	}
+	if _, ok := ap.ConstFoldCache[expr]; !ok {
+		t.Fatal("expected expression to be cached after first fold")
+	}
+
+	// Poison the cache entry with an obviously wrong value.
+	ap.ConstFoldCache[expr] = ConstValue{Kind: ConstString, Str: "poisoned"}
+
+	second, _ := ConstFold(expr, ap)
+	if !constValueEqual(second, ConstValue{Kind: ConstString, Str: "poisoned"}) {
+		t.Errorf("second fold recomputed instead of using cache: got %#v", second)
+	}
+}
+
+// TestConstFoldPreservesKeyOrder verifies that map and block folding preserve
+// source order in the Keys slice. This is a regression test for a bug where
+// ConstValue used a map[string]ConstValue under the hood, causing golden
+// codegen output to flake due to Go's randomized map iteration.
+func TestConstFoldPreservesKeyOrder(t *testing.T) {
+	str := func(s string) *ast.StringLiteral {
+		return &ast.StringLiteral{BaseNode: ast.NewTerminal(token.Token{Type: token.STRING, Literal: `"x"`}), Value: s}
+	}
+	i := func(n float64) *ast.NumberLiteral {
+		return &ast.NumberLiteral{BaseNode: ast.NewTerminal(token.Token{Type: token.NUMBER, Literal: "0"}), Value: n}
+	}
+
+	t.Run("map literal", func(t *testing.T) {
+		// Use keys whose natural alphabetical ordering differs from source order,
+		// so a map-based implementation would flake (and sorted output would
+		// visibly reorder to a, b, c, d).
+		expr := &ast.MapLiteral{Entries: []ast.MapEntry{
+			{Key: str("d"), Value: i(1)},
+			{Key: str("b"), Value: i(2)},
+			{Key: str("a"), Value: i(3)},
+			{Key: str("c"), Value: i(4)},
+		}}
+		got, _ := ConstFold(expr, nil)
+		wantKeys := []string{"d", "b", "a", "c"}
+		if len(got.Keys) != len(wantKeys) {
+			t.Fatalf("Keys length = %d, want %d", len(got.Keys), len(wantKeys))
+		}
+		for idx, k := range wantKeys {
+			if got.Keys[idx] != k {
+				t.Errorf("Keys[%d] = %q, want %q", idx, got.Keys[idx], k)
+			}
+		}
+	})
+
+	t.Run("block body", func(t *testing.T) {
+		be := &ast.BlockExpression{BlockBody: ast.BlockBody{
+			Kind: "model",
+			Assignments: []*ast.Assignment{
+				{Name: "provider", Value: str("openai")},
+				{Name: "model_name", Value: str("gpt-4o")},
+				{Name: "temperature", Value: i(0.7)},
+			},
+		}}
+		got, _ := ConstFold(be, nil)
+		wantKeys := []string{"provider", "model_name", "temperature"}
+		if len(got.Keys) != len(wantKeys) {
+			t.Fatalf("Keys length = %d, want %d", len(got.Keys), len(wantKeys))
+		}
+		for idx, k := range wantKeys {
+			if got.Keys[idx] != k {
+				t.Errorf("Keys[%d] = %q, want %q", idx, got.Keys[idx], k)
+			}
+		}
+	})
 }

--- a/compiler/codegen/langgraph/expr.go
+++ b/compiler/codegen/langgraph/expr.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"strings"
 
+	"github.com/thakee/orca/compiler/analyzer"
 	"github.com/thakee/orca/compiler/ast"
 	"github.com/thakee/orca/compiler/token"
 	"github.com/thakee/orca/compiler/types"
@@ -16,7 +17,21 @@ import (
 // Unknown or nil interfaces are handled explicitly: nil becomes Python None;
 // any other type panics so mistakes surface immediately instead of emitting
 // invalid Python.
-func exprToSource(expr ast.Expression) string {
+func (b *LangGraphBackend) exprToSource(expr ast.Expression) string {
+
+	// TODO: We're not folding block expressions cause currently we are depend on the block
+	// body (the defined block one) to generate workflow nodes, but that behavior should be changed.
+	//
+	// Here is another !! BUG !! if we use inline block.
+	//     "a": _orca__block("agent", model=_orca__block("model", provider="openai", model_name="gpt-4o", ), ...)
+	//     "b": _orca__block("agent", model=_orca__block("model", model_name="gpt-4o", provider="openai", ), ...)
+	// Source order is provider then model_name in both cases. constValToSource's ConstMap and ConstBlock cases iterate constVal.KeyValue which is a
+	// map[string]ConstValue — Go map iteration is randomized, so every codegen run produces different Python. Goldens will flake.
+	constVal, ok := b.Program.ConstFoldCache[expr]
+	if ok && constVal.Kind != analyzer.ConstUnknown && constVal.Kind != analyzer.ConstBlock {
+		return constValToSource(b, constVal)
+	}
+
 	switch e := expr.(type) {
 	case nil:
 		return "None"
@@ -40,23 +55,23 @@ func exprToSource(expr ast.Expression) string {
 			return e.Value
 		}
 	case *ast.MemberAccess:
-		return exprToSource(e.Object) + "." + e.Member
+		return b.exprToSource(e.Object) + "." + e.Member
 	case *ast.Subscription:
 		var indices []string
 		for _, idx := range e.Indices {
-			indices = append(indices, exprToSource(idx))
+			indices = append(indices, b.exprToSource(idx))
 		}
-		return exprToSource(e.Object) + "[" + strings.Join(indices, ", ") + "]"
+		return b.exprToSource(e.Object) + "[" + strings.Join(indices, ", ") + "]"
 	case *ast.ListLiteral:
 		var elems []string
 		for _, el := range e.Elements {
-			elems = append(elems, exprToSource(el))
+			elems = append(elems, b.exprToSource(el))
 		}
 		return "[" + strings.Join(elems, ", ") + "]"
 	case *ast.MapLiteral:
 		var entries []string
 		for _, entry := range e.Entries {
-			entries = append(entries, exprToSource(entry.Key)+": "+exprToSource(entry.Value))
+			entries = append(entries, b.exprToSource(entry.Key)+": "+b.exprToSource(entry.Value))
 		}
 		return "{" + strings.Join(entries, ", ") + "}"
 	case *ast.BinaryExpression:
@@ -64,42 +79,42 @@ func exprToSource(expr ast.Expression) string {
 			// FIXME: Dont hard code like this
 			// "_orca__block("workflow_chain", left, right)"
 			return orcaPrefix + "block(\"" + types.AnnotationWorkflowChain +
-				"\", left=" + exprToSource(e.Left) +
-				", right=" + exprToSource(e.Right) + ")"
+				"\", left=" + b.exprToSource(e.Left) +
+				", right=" + b.exprToSource(e.Right) + ")"
 		}
-		return exprToSource(e.Left) + " " + e.Operator.Literal + " " + exprToSource(e.Right)
+		return b.exprToSource(e.Left) + " " + e.Operator.Literal + " " + b.exprToSource(e.Right)
 	case *ast.CallExpression:
 		var args []string
 		for _, arg := range e.Arguments {
-			args = append(args, exprToSource(arg))
+			args = append(args, b.exprToSource(arg))
 		}
-		return exprToSource(e.Callee) + "(" + strings.Join(args, ", ") + ")"
+		return b.exprToSource(e.Callee) + "(" + strings.Join(args, ", ") + ")"
 	case *ast.TernaryExpression:
-		return "(" + exprToSource(e.TrueExpr) + " if " + exprToSource(e.Condition) + " else " + exprToSource(e.FalseExpr) + ")"
+		return "(" + b.exprToSource(e.TrueExpr) + " if " + b.exprToSource(e.Condition) + " else " + b.exprToSource(e.FalseExpr) + ")"
 	case *ast.Lambda:
 		var params []string
 		for _, p := range e.Params {
 			params = append(params, p.Name.Value)
 		}
 		if len(params) == 0 {
-			return "lambda: " + exprToSource(e.Body)
+			return "lambda: " + b.exprToSource(e.Body)
 		}
-		return "lambda " + strings.Join(params, ", ") + ": " + exprToSource(e.Body)
+		return "lambda " + strings.Join(params, ", ") + ": " + b.exprToSource(e.Body)
 	case *ast.BlockExpression:
-		return blockCallSource(&e.BlockBody, "")
+		return blockCallSource(b, &e.BlockBody, "")
 	default:
 		panic(fmt.Sprintf("langgraph.exprToSource: unsupported ast.Expression type %T", e))
 	}
 }
 
 // annotationToSource emits one `__orca_meta("name", ...args)` from an AST annotation.
-func annotationToSource(ann *ast.Annotation) string {
+func annotationToSource(b *LangGraphBackend, ann *ast.Annotation) string {
 	var sb strings.Builder
 	sb.WriteString(orcaPrefix + "meta(")
 	sb.WriteString(fmt.Sprintf("%q", ann.Name))
 	for _, arg := range ann.Arguments {
 		sb.WriteString(", ")
-		sb.WriteString(exprToSource(arg))
+		sb.WriteString(b.exprToSource(arg))
 	}
 	sb.WriteString(")")
 	return sb.String()
@@ -123,22 +138,22 @@ func indentNonEmptyLines(s, prefix string) string {
 // annotationsListSourceMultiline builds a multi-line Python list of orca.meta(...)
 // calls. argIndent is the indentation of the opening "[" and closing "]" lines;
 // list elements are indented one level deeper.
-func annotationsListSourceMultiline(anns []*ast.Annotation, argIndent string) string {
+func annotationsListSourceMultiline(b *LangGraphBackend, anns []*ast.Annotation, argIndent string) string {
 	if len(anns) == 0 {
 		return "[]"
 	}
 	metaIndent := argIndent + "    "
-	var b strings.Builder
-	b.WriteString(argIndent)
-	b.WriteString("[\n")
+	var sb strings.Builder
+	sb.WriteString(argIndent)
+	sb.WriteString("[\n")
 	for _, a := range anns {
-		b.WriteString(metaIndent)
-		b.WriteString(annotationToSource(a))
-		b.WriteString(",\n")
+		sb.WriteString(metaIndent)
+		sb.WriteString(annotationToSource(b, a))
+		sb.WriteString(",\n")
 	}
-	b.WriteString(argIndent)
-	b.WriteString("]")
-	return b.String()
+	sb.WriteString(argIndent)
+	sb.WriteString("]")
+	return sb.String()
 }
 
 // wrapWithMetaIfNeeded returns inner unchanged when there are no annotations.
@@ -146,11 +161,11 @@ func annotationsListSourceMultiline(anns []*ast.Annotation, argIndent string) st
 // meta lists stay readable. argIndent prefixes each line of the inner value and
 // the meta list contents; closeIndent prefixes the closing ")" ("" at top level,
 // fieldIndent when the with_meta is a field RHS so ")" aligns with "key=").
-func wrapWithMetaIfNeeded(inner string, anns []*ast.Annotation, argIndent, closeIndent string) string {
+func wrapWithMetaIfNeeded(b *LangGraphBackend, inner string, anns []*ast.Annotation, argIndent, closeIndent string) string {
 	if len(anns) == 0 {
 		return inner
 	}
-	listSrc := annotationsListSourceMultiline(anns, argIndent)
+	listSrc := annotationsListSourceMultiline(b, anns, argIndent)
 	innerIndented := indentNonEmptyLines(inner, argIndent)
 	var sb strings.Builder
 	sb.WriteString(orcaPrefix + "with_meta(\n")
@@ -166,23 +181,23 @@ func wrapWithMetaIfNeeded(inner string, anns []*ast.Annotation, argIndent, close
 // assignmentValueSource emits the RHS for a block field, wrapping with with_meta
 // only when the assignment carries annotations. fieldIndent is the block body's
 // line prefix for assignments ("    " in multi-line blocks, "" when inline).
-func assignmentValueSource(assign *ast.Assignment, fieldIndent string) string {
+func assignmentValueSource(b *LangGraphBackend, assign *ast.Assignment, fieldIndent string) string {
 	if assign == nil {
 		return "None"
 	}
-	val := exprToSource(assign.Value)
+	val := b.exprToSource(assign.Value)
 	argIndent := fieldIndent + "    "
-	return wrapWithMetaIfNeeded(val, assign.Annotations, argIndent, fieldIndent)
+	return wrapWithMetaIfNeeded(b, val, assign.Annotations, argIndent, fieldIndent)
 }
 
 // topLevelBlockSource emits the full Python RHS for a top-level block statement,
 // including optional block-level annotations around the orca.<kind>(...) call.
-func topLevelBlockSource(block *ast.BlockStatement) string {
+func topLevelBlockSource(b *LangGraphBackend, block *ast.BlockStatement) string {
 	if block == nil {
 		panic("BUG: topLevelBlockSource called with nil block")
 	}
-	inner := blockCallSource(&block.BlockBody, "    ")
-	return wrapWithMetaIfNeeded(inner, block.Annotations, "    ", "")
+	inner := blockCallSource(b, &block.BlockBody, "    ")
+	return wrapWithMetaIfNeeded(b, inner, block.Annotations, "    ", "")
 }
 
 // blockCallSource generates a Python expression calling the orca runtime for
@@ -197,7 +212,7 @@ func topLevelBlockSource(block *ast.BlockStatement) string {
 //	)
 //
 // When indent is empty, everything is on one line (used for inline blocks).
-func blockCallSource(body *ast.BlockBody, indent string) string {
+func blockCallSource(b *LangGraphBackend, body *ast.BlockBody, indent string) string {
 	var sb strings.Builder
 	sb.WriteString(fmt.Sprintf("%sblock(%q, ", orcaPrefix, body.Kind))
 
@@ -205,7 +220,7 @@ func blockCallSource(body *ast.BlockBody, indent string) string {
 		for _, assign := range body.Assignments {
 			sb.WriteString(assign.Name)
 			sb.WriteString("=")
-			sb.WriteString(assignmentValueSource(assign, indent))
+			sb.WriteString(assignmentValueSource(b, assign, indent))
 			sb.WriteString(", ")
 		}
 	} else {
@@ -214,7 +229,7 @@ func blockCallSource(body *ast.BlockBody, indent string) string {
 			sb.WriteString(indent)
 			sb.WriteString(assign.Name)
 			sb.WriteString("=")
-			sb.WriteString(assignmentValueSource(assign, indent))
+			sb.WriteString(assignmentValueSource(b, assign, indent))
 			sb.WriteString(",")
 		}
 		if len(body.Assignments) > 0 {
@@ -226,6 +241,63 @@ func blockCallSource(body *ast.BlockBody, indent string) string {
 	return sb.String()
 }
 
+func constValToSource(b *LangGraphBackend, constVal analyzer.ConstValue) string {
+
+	// TODO:
+	// Cost folded blocks are not inlined, Rethink this situaion.
+	// Also a lambda can return a block that has const value (compile time known) how to handle that?
+	if constVal.Kind == analyzer.ConstUnknown || constVal.Kind == analyzer.ConstBlock {
+		return b.exprToSource(constVal.Expr)
+	}
+
+	switch constVal.Kind {
+	case analyzer.ConstString:
+		return fmt.Sprintf("%q", constVal.Str)
+	case analyzer.ConstNumber:
+		return formatFloat(constVal.Number)
+	case analyzer.ConstBool:
+		if constVal.Bool {
+			return "True"
+		}
+		return "False"
+	case analyzer.ConstNull:
+		return "None"
+	case analyzer.ConstList:
+		var elems []string
+		for _, elem := range constVal.List {
+			elems = append(elems, constValToSource(b, elem))
+		}
+		return "[" + strings.Join(elems, ", ") + "]"
+	case analyzer.ConstMap:
+		var entries []string
+		for i, key := range constVal.Keys {
+			// TODO: Handle escaped quotes and newlines in the string.
+			value := constVal.Values[i]
+			entries = append(entries, "\""+key+"\": "+constValToSource(b, value))
+		}
+		return "{" + strings.Join(entries, ", ") + "}"
+	case analyzer.ConstBlock:
+		// TODO: If the const block has k=v, expressions it set to Partial constant and
+		// those expressions are not folded, we should handle them somehow.
+
+		// blockCallSource and this uses almost same logic make sure they are in sync.
+		var sb strings.Builder
+		sb.WriteString(fmt.Sprintf("%sblock(%q, ", orcaPrefix, constVal.BlockKind))
+		for i, key := range constVal.Keys {
+			value := constVal.Values[i]
+			sb.WriteString(key)
+			sb.WriteString("=")
+			sb.WriteString(constValToSource(b, value))
+			sb.WriteString(", ")
+		}
+		sb.WriteString(")")
+		return sb.String()
+	}
+
+	panic(fmt.Sprintf("langgraph.constValToSource: unsupported analyzer.ConstKind %d", constVal.Kind))
+}
+
+// TODO: Move this to a helper function.
 // formatFloat formats numbers for Python source. Whole values use integer
 // literals (no ".0"); fractional values use %g.
 func formatFloat(f float64) string {

--- a/compiler/codegen/langgraph/expr_test.go
+++ b/compiler/codegen/langgraph/expr_test.go
@@ -4,7 +4,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/thakee/orca/compiler/analyzer"
 	"github.com/thakee/orca/compiler/ast"
+	"github.com/thakee/orca/compiler/codegen"
+	"github.com/thakee/orca/compiler/lexer"
+	"github.com/thakee/orca/compiler/parser"
 	"github.com/thakee/orca/compiler/token"
 	"github.com/thakee/orca/compiler/types"
 )
@@ -316,7 +320,8 @@ func TestExprToSource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := exprToSource(tt.expr)
+			b := &LangGraphBackend{}
+			got := b.exprToSource(tt.expr)
 			if got != tt.expected {
 				t.Errorf("expected %q, got %q", tt.expected, got)
 			}
@@ -326,7 +331,8 @@ func TestExprToSource(t *testing.T) {
 
 // TestExprToSourceNilExpression verifies a nil Expression maps to Python None.
 func TestExprToSourceNilExpression(t *testing.T) {
-	if got := exprToSource(nil); got != "None" {
+	b := &LangGraphBackend{}
+	if got := b.exprToSource(nil); got != "None" {
 		t.Fatalf("exprToSource(nil) = %q, want None", got)
 	}
 }
@@ -358,7 +364,8 @@ func TestExprToSourceExhaustiveKinds(t *testing.T) {
 					t.Fatalf("panic: %v", r)
 				}
 			}()
-			if exprToSource(tc.expr) == "" {
+			b := &LangGraphBackend{}
+			if b.exprToSource(tc.expr) == "" {
 				t.Fatal("empty result")
 			}
 		})
@@ -399,7 +406,8 @@ func TestAnnotationToSource(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := annotationToSource(tt.ann)
+			b := &LangGraphBackend{}
+			got := annotationToSource(b, tt.ann)
 			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
@@ -480,7 +488,8 @@ func TestWrapWithMetaIfNeeded(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := wrapWithMetaIfNeeded(tt.inner, tt.anns, tt.argIndent, tt.closeIndent)
+			b := &LangGraphBackend{}
+			got := wrapWithMetaIfNeeded(b, tt.inner, tt.anns, tt.argIndent, tt.closeIndent)
 			if got != tt.want {
 				t.Errorf("got %q, want %q", got, tt.want)
 			}
@@ -503,7 +512,8 @@ func TestTopLevelBlockSource(t *testing.T) {
 			},
 		},
 	}
-	got := topLevelBlockSource(block)
+	b := &LangGraphBackend{}
+	got := topLevelBlockSource(b, block)
 	if !strings.Contains(got, `_orca__with_meta(`) || !strings.Contains(got, `_orca__meta("sensitive")`) {
 		t.Fatalf("expected with_meta and sensitive meta, got:\n%s", got)
 	}
@@ -521,7 +531,7 @@ func TestTopLevelBlockSource(t *testing.T) {
 			},
 		},
 	}
-	plainGot := topLevelBlockSource(plain)
+	plainGot := topLevelBlockSource(b, plain)
 	if strings.Contains(plainGot, "with_meta") {
 		t.Fatalf("expected no with_meta without block annotations, got %q", plainGot)
 	}
@@ -552,5 +562,141 @@ func TestFormatFloat(t *testing.T) {
 				t.Errorf("formatFloat(%v): expected %q, got %q", tt.input, tt.expected, got)
 			}
 		})
+	}
+}
+
+// TestConstValToSource covers each ConstKind rendered to Python source.
+// Partial/Unknown children that fall back to the AST are covered separately
+// in TestExprToSourceCachePath.
+func TestConstValToSource(t *testing.T) {
+	tests := []struct {
+		name string
+		in   analyzer.ConstValue
+		want string
+	}{
+		{"string", analyzer.ConstValue{Kind: analyzer.ConstString, Str: "hello"}, `"hello"`},
+		{"string with quotes", analyzer.ConstValue{Kind: analyzer.ConstString, Str: `say "hi"`}, `"say \"hi\""`},
+		{"number whole", analyzer.ConstValue{Kind: analyzer.ConstNumber, Number: 42}, "42"},
+		{"number fractional", analyzer.ConstValue{Kind: analyzer.ConstNumber, Number: 0.5}, "0.5"},
+		{"bool true", analyzer.ConstValue{Kind: analyzer.ConstBool, Bool: true}, "True"},
+		{"bool false", analyzer.ConstValue{Kind: analyzer.ConstBool, Bool: false}, "False"},
+		{"null", analyzer.ConstValue{Kind: analyzer.ConstNull}, "None"},
+		{
+			name: "list of mixed primitives",
+			in: analyzer.ConstValue{Kind: analyzer.ConstList, List: []analyzer.ConstValue{
+				{Kind: analyzer.ConstNumber, Number: 1},
+				{Kind: analyzer.ConstString, Str: "two"},
+				{Kind: analyzer.ConstBool, Bool: true},
+			}},
+			want: `[1, "two", True]`,
+		},
+		{
+			name: "map preserves source order",
+			in: analyzer.ConstValue{
+				Kind:   analyzer.ConstMap,
+				Keys:   []string{"z", "a"},
+				Values: []analyzer.ConstValue{{Kind: analyzer.ConstNumber, Number: 1}, {Kind: analyzer.ConstNumber, Number: 2}},
+			},
+			want: `{"z": 1, "a": 2}`,
+		},
+		// Note: ConstBlock is intentionally not tested here — constValToSource
+		// routes ConstBlock values back through exprToSource(constVal.Expr) so
+		// named block references stay as identifiers instead of being inlined
+		// (see TestExprToSourceNamedBlockRefNotInlined).
+	}
+
+	b := &LangGraphBackend{}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := constValToSource(b, tt.in)
+			if got != tt.want {
+				t.Errorf("constValToSource() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExprToSourceCachePath verifies that when ConstFoldCache contains a
+// non-Unknown entry for an expression, exprToSource routes it through
+// constValToSource, and that a ConstUnknown entry is bypassed (falling back to
+// the AST switch). A zero backend with no cache should always use the AST path.
+func TestExprToSourceCachePath(t *testing.T) {
+	numExpr := &ast.NumberLiteral{
+		BaseNode: ast.NewTerminal(token.Token{Type: token.NUMBER, Literal: "1"}),
+		Value:    1,
+	}
+
+	t.Run("cache hit routes through constValToSource", func(t *testing.T) {
+		b := &LangGraphBackend{BaseBackend: codegen.BaseBackend{Program: analyzer.AnalyzedProgram{
+			ConstFoldCache: map[ast.Expression]analyzer.ConstValue{
+				numExpr: {Kind: analyzer.ConstNumber, Number: 999},
+			},
+		}}}
+		if got := b.exprToSource(numExpr); got != "999" {
+			t.Errorf("exprToSource() = %q, want cached %q", got, "999")
+		}
+	})
+
+	t.Run("unknown cache entry falls through to AST", func(t *testing.T) {
+		b := &LangGraphBackend{BaseBackend: codegen.BaseBackend{Program: analyzer.AnalyzedProgram{
+			ConstFoldCache: map[ast.Expression]analyzer.ConstValue{
+				numExpr: {Kind: analyzer.ConstUnknown, Expr: numExpr},
+			},
+		}}}
+		// The AST path emits the literal value; the cached Unknown must not short-circuit.
+		if got := b.exprToSource(numExpr); got != "1" {
+			t.Errorf("exprToSource() = %q, want AST path %q", got, "1")
+		}
+	})
+
+	t.Run("no cache uses AST path", func(t *testing.T) {
+		b := &LangGraphBackend{}
+		if got := b.exprToSource(numExpr); got != "1" {
+			t.Errorf("exprToSource() = %q, want %q", got, "1")
+		}
+	})
+}
+
+// TestExprToSourceNamedBlockRefNotInlined is a regression test: an identifier
+// referencing a named top-level block must emit as the Python variable name,
+// not get replaced by an inlined _orca__block(...) call sourced from the
+// ConstFoldCache. Without this guard the single top-level block definition
+// becomes unused and each reference duplicates the block body.
+func TestExprToSourceNamedBlockRefNotInlined(t *testing.T) {
+	src := `model gpt4 {
+  provider = "openai"
+  model_name = "gpt-4o"
+}
+agent writer {
+  model = gpt4
+  persona = "You write things."
+}`
+	l := lexer.New(src, "")
+	p := parser.New(l)
+	program := p.ParseProgram()
+	if errs := p.Errors(); len(errs) > 0 {
+		t.Fatalf("parse errors: %v", errs)
+	}
+	ap := analyzer.Analyze(program)
+	if len(ap.Diagnostics) > 0 {
+		t.Fatalf("analyze diagnostics: %v", ap.Diagnostics)
+	}
+
+	writer := program.FindBlockWithName("writer")
+	if writer == nil {
+		t.Fatal("writer block not found")
+	}
+	modelField, ok := writer.GetFieldExpression("model")
+	if !ok {
+		t.Fatal("writer.model field missing")
+	}
+
+	b := &LangGraphBackend{BaseBackend: codegen.BaseBackend{Program: ap}}
+	got := b.exprToSource(modelField)
+	if got != "gpt4" {
+		t.Errorf("exprToSource(writer.model) = %q, want %q (named block refs must not be inlined)", got, "gpt4")
+	}
+	if strings.Contains(got, "_orca__block") {
+		t.Errorf("named block identifier was inlined: %q", got)
 	}
 }

--- a/compiler/codegen/langgraph/langgraph.go
+++ b/compiler/codegen/langgraph/langgraph.go
@@ -77,6 +77,8 @@ func (b *LangGraphBackend) generateMain() string {
 	s.WriteString(embeddedRuntime)
 	s.WriteString("\n")
 
+	// FIXME: The schema blocks should also be sorted and written in order
+	// along with the other blocks.
 	b.writeSchemaSection(&s, schemaBlocks)
 	b.writeBlocksInOrder(&s)
 
@@ -115,13 +117,6 @@ func (b *LangGraphBackend) writeBlocksInOrder(s *strings.Builder) {
 // based on block kind.
 func (b *LangGraphBackend) writeBlock(s *strings.Builder, block *ast.BlockStatement) {
 	switch block.Kind {
-	case types.BlockKindModel:
-		s.WriteString("\n")
-		fmt.Fprintf(s, "%s = %s\n", block.Name, modelBlockSource(block))
-
-	case types.BlockKindTool:
-		s.WriteString("\n")
-		fmt.Fprintf(s, "%s = %s\n", block.Name, topLevelBlockSource(block))
 
 	case types.BlockKindWorkflow:
 		if rw, ok := b.resolvedWorkflows[block.Name]; ok {
@@ -133,7 +128,7 @@ func (b *LangGraphBackend) writeBlock(s *strings.Builder, block *ast.BlockStatem
 	default:
 		// Generic block: let, agent, knowledge, cron, webhook.
 		s.WriteString("\n")
-		fmt.Fprintf(s, "%s = %s\n", block.Name, topLevelBlockSource(block))
+		fmt.Fprintf(s, "%s = %s\n", block.Name, topLevelBlockSource(b, block))
 	}
 }
 

--- a/compiler/codegen/langgraph/langgraph_test.go
+++ b/compiler/codegen/langgraph/langgraph_test.go
@@ -119,7 +119,7 @@ func TestWriteBlocksInOrder(t *testing.T) {
 			program: programWithModels(modelBlock("gpt4", "openai", "gpt-4o")),
 			wantSubstrings: []string{
 				`gpt4 = _orca__block("model", `,
-				"provider_class=ChatOpenAI",
+				`provider="openai"`,
 			},
 		},
 		{
@@ -298,7 +298,8 @@ func TestWriteModel(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var s strings.Builder
-			fmt.Fprintf(&s, "%s = %s\n", tt.block.Name, topLevelBlockSource(tt.block))
+			b := &LangGraphBackend{}
+			fmt.Fprintf(&s, "%s = %s\n", tt.block.Name, topLevelBlockSource(b, tt.block))
 			result := s.String()
 
 			for _, exp := range tt.contains {
@@ -320,7 +321,8 @@ func TestWriteModel(t *testing.T) {
 func TestWriteModelUnknownProvider(t *testing.T) {
 	block := modelBlock("m1", "unknown_provider", "some-model")
 	var s strings.Builder
-	fmt.Fprintf(&s, "%s = %s\n", block.Name, topLevelBlockSource(block))
+	b := &LangGraphBackend{}
+	fmt.Fprintf(&s, "%s = %s\n", block.Name, topLevelBlockSource(b, block))
 	if !strings.Contains(s.String(), `provider="unknown_provider"`) {
 		t.Fatalf("expected _orca__model output, got:\n%s", s.String())
 	}
@@ -404,7 +406,8 @@ func TestWriteAgent(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var s strings.Builder
-			fmt.Fprintf(&s, "%s = %s\n", tt.block.Name, topLevelBlockSource(tt.block))
+			b := &LangGraphBackend{}
+			fmt.Fprintf(&s, "%s = %s\n", tt.block.Name, topLevelBlockSource(b, tt.block))
 			result := s.String()
 
 			for _, want := range tt.contains {
@@ -446,7 +449,8 @@ func TestWriteSchema(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var s strings.Builder
-			fmt.Fprintf(&s, "%s = %s\n", tt.block.Name, topLevelBlockSource(tt.block))
+			b := &LangGraphBackend{}
+			fmt.Fprintf(&s, "%s = %s\n", tt.block.Name, topLevelBlockSource(b, tt.block))
 			result := s.String()
 			for _, want := range tt.contains {
 				if !strings.Contains(result, want) {
@@ -487,7 +491,8 @@ func TestWriteKnowledge(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var s strings.Builder
-			fmt.Fprintf(&s, "%s = %s\n", tt.block.Name, topLevelBlockSource(tt.block))
+			b := &LangGraphBackend{}
+			fmt.Fprintf(&s, "%s = %s\n", tt.block.Name, topLevelBlockSource(b, tt.block))
 			result := s.String()
 			for _, want := range tt.contains {
 				if !strings.Contains(result, want) {

--- a/compiler/codegen/langgraph/providers.go
+++ b/compiler/codegen/langgraph/providers.go
@@ -4,7 +4,6 @@ package langgraph
 import (
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/thakee/orca/compiler/analyzer"
 	"github.com/thakee/orca/compiler/ast"
@@ -103,7 +102,7 @@ func (b *LangGraphBackend) resolveProviders() {
 			continue
 		}
 
-		v, d := analyzer.ConstFold(expr, b.Program)
+		v, d := analyzer.ConstFold(expr, &b.Program)
 		b.Program.Diagnostics = append(b.Program.Diagnostics, d...)
 
 		if v.Kind != analyzer.ConstString {
@@ -138,41 +137,6 @@ func (b *LangGraphBackend) resolveProviders() {
 	}
 
 	b.resolvedProviders = resolvedProviders{providerImports: imports}
-}
-
-// modelBlockSource generates the __orca_model(...) call with the provider field
-// substituted from a string to the resolved class name.
-func modelBlockSource(model *ast.BlockStatement) string {
-	var sb strings.Builder
-	sb.WriteString(fmt.Sprintf("%sblock(%q, ", orcaPrefix, "model"))
-
-	indent := "    "
-	for _, assign := range model.Assignments {
-		sb.WriteString("\n")
-		sb.WriteString(indent)
-
-		if assign.Name == "provider" {
-			if str, ok := assign.Value.(*ast.StringLiteral); ok {
-				if className := providerClassName(str.Value); className != "" {
-					sb.WriteString("provider_class=")
-					sb.WriteString(className)
-					sb.WriteString(",")
-					continue
-				}
-			}
-		}
-
-		sb.WriteString(assign.Name)
-		sb.WriteString("=")
-		sb.WriteString(assignmentValueSource(assign, indent))
-		sb.WriteString(",")
-	}
-	if len(model.Assignments) > 0 {
-		sb.WriteString("\n")
-	}
-	sb.WriteString(")")
-
-	return wrapWithMetaIfNeeded(sb.String(), model.Annotations, "    ", "")
 }
 
 // collectBodiesByKind returns all BlockBody nodes matching the given kind,

--- a/compiler/codegen/langgraph/runtime.py
+++ b/compiler/codegen/langgraph/runtime.py
@@ -37,13 +37,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),

--- a/compiler/codegen/langgraph/workflow.go
+++ b/compiler/codegen/langgraph/workflow.go
@@ -129,9 +129,9 @@ func (b *LangGraphBackend) writeWorkflow(s *strings.Builder, rw workflow.Resolve
 	writeRouter(s, rw, stateName)
 
 	// Branch router functions.
-	for i, branch := range rw.Branches {
+	for _, branch := range rw.Branches {
 		s.WriteString("\n")
-		writeBranchRouter(s, rw, stateName, branch, i)
+		writeBranchRouter(b, s, rw, stateName, branch)
 	}
 
 	// StateGraph construction.
@@ -152,7 +152,7 @@ func (b *LangGraphBackend) writeWorkflow(s *strings.Builder, rw workflow.Resolve
 	for _, branch := range rw.Branches {
 		routerName := branchRouterFuncName(rw.Name, branch.Name)
 		fmt.Fprintf(s, "%s.add_conditional_edges(%q, %s", rw.Name, branch.Name, routerName)
-		writeBranchRouteMap(s, branch)
+		writeBranchRouteMap(b, s, branch)
 		s.WriteString(")\n")
 	}
 
@@ -303,7 +303,7 @@ func (b *LangGraphBackend) writeWorkflowNode(s *strings.Builder, rw workflow.Res
 	// so resolve them via rw.FindBranch before falling back to the symbol
 	// table / AST lookup used for named blocks like agent/tool.
 	if branch := rw.FindBranch(node); branch != nil {
-		writeBranchNodeBody(s, branch)
+		writeBranchNodeBody(b, s, branch)
 		return
 	}
 
@@ -336,7 +336,7 @@ func branchRouterFuncName(workflowName string, branchName string) string {
 // always contains the default key (auto-wired to END if the user didn't
 // provide one — see writeBranchRouteMap), so LangGraph never receives an
 // unknown key at runtime.
-func writeBranchRouter(s *strings.Builder, rw workflow.ResolvedWorkflow, stateName string, branch workflow.Branch, branchIndex int) {
+func writeBranchRouter(b *LangGraphBackend, s *strings.Builder, rw workflow.ResolvedWorkflow, stateName string, branch workflow.Branch) {
 	funcName := branchRouterFuncName(rw.Name, branch.Name)
 	fmt.Fprintf(s, "def %s(state: %s) -> Any:\n", funcName, stateName)
 	fmt.Fprintf(s, "    \"\"\"Branch router for %q.\"\"\"\n", branch.Name)
@@ -347,7 +347,7 @@ func writeBranchRouter(s *strings.Builder, rw workflow.ResolvedWorkflow, stateNa
 		if len(route.EntryNodes) == 0 {
 			continue
 		}
-		knownKeys = append(knownKeys, exprToSource(route.Key))
+		knownKeys = append(knownKeys, b.exprToSource(route.Key))
 	}
 	if len(knownKeys) > 0 {
 		fmt.Fprintf(s, "    if _key in {%s}:\n", strings.Join(knownKeys, ", "))
@@ -367,9 +367,9 @@ func writeBranchRouter(s *strings.Builder, rw workflow.ResolvedWorkflow, stateNa
 //
 // The caller is responsible for writing the function signature, docstring,
 // and the _predecessors / _input preamble.
-func writeBranchNodeBody(s *strings.Builder, branch *workflow.Branch) {
+func writeBranchNodeBody(b *LangGraphBackend, s *strings.Builder, branch *workflow.Branch) {
 	if branch.Transform != nil {
-		fmt.Fprintf(s, "    _route_key = (%s)(_input)\n", exprToSource(branch.Transform))
+		fmt.Fprintf(s, "    _route_key = (%s)(_input)\n", b.exprToSource(branch.Transform))
 	} else {
 		s.WriteString("    _route_key = _input\n")
 	}
@@ -381,7 +381,7 @@ func writeBranchNodeBody(s *strings.Builder, branch *workflow.Branch) {
 // EntryNodes are skipped (unsupported route value shapes). If the user did
 // not provide a workflow.BranchRouteKeyDefault entry, one is auto-wired to
 // END so LangGraph always has a fallback.
-func writeBranchRouteMap(s *strings.Builder, branch workflow.Branch) {
+func writeBranchRouteMap(b *LangGraphBackend, s *strings.Builder, branch workflow.Branch) {
 	s.WriteString(", {")
 	first := true
 	hasDefault := false
@@ -393,7 +393,7 @@ func writeBranchRouteMap(s *strings.Builder, branch workflow.Branch) {
 			s.WriteString(", ")
 		}
 		first = false
-		fmt.Fprintf(s, "%s: %q", exprToSource(route.Key), route.EntryNodes[0])
+		fmt.Fprintf(s, "%s: %q", b.exprToSource(route.Key), route.EntryNodes[0])
 		if strLit, ok := route.Key.(*ast.StringLiteral); ok && strLit.Value == workflow.BranchRouteKeyDefault {
 			hasDefault = true
 		}

--- a/compiler/codegen/testdata/golden/agent_basic.py
+++ b/compiler/codegen/testdata/golden/agent_basic.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -96,7 +116,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/agent_field_annotated.py
+++ b/compiler/codegen/testdata/golden/agent_field_annotated.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -96,7 +116,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/agent_with_tools.py
+++ b/compiler/codegen/testdata/golden/agent_with_tools.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -96,7 +116,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
     temperature=0.5,
 )

--- a/compiler/codegen/testdata/golden/knowledge_basic.py
+++ b/compiler/codegen/testdata/golden/knowledge_basic.py
@@ -48,13 +48,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),

--- a/compiler/codegen/testdata/golden/lambda_basic.py
+++ b/compiler/codegen/testdata/golden/lambda_basic.py
@@ -48,13 +48,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),

--- a/compiler/codegen/testdata/golden/let_basic.py
+++ b/compiler/codegen/testdata/golden/let_basic.py
@@ -48,13 +48,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),

--- a/compiler/codegen/testdata/golden/let_expressions.py
+++ b/compiler/codegen/testdata/golden/let_expressions.py
@@ -48,13 +48,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),

--- a/compiler/codegen/testdata/golden/mixed_let_model.py
+++ b/compiler/codegen/testdata/golden/mixed_let_model.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -100,7 +120,7 @@ vars = _orca__block("let",
 )
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
     temperature=1,
 )

--- a/compiler/codegen/testdata/golden/model_basic.py
+++ b/compiler/codegen/testdata/golden/model_basic.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -96,7 +116,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
     temperature=0.7,
 )

--- a/compiler/codegen/testdata/golden/model_field_annotated.py
+++ b/compiler/codegen/testdata/golden/model_field_annotated.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -96,6 +116,11 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider=_orca__with_meta(
+        "openai",
+        [
+            _orca__meta("desc", "LLM provider id"),
+        ],
+    ),
     model_name="gpt-4o",
 )

--- a/compiler/codegen/testdata/golden/model_multi_provider.py
+++ b/compiler/codegen/testdata/golden/model_multi_provider.py
@@ -51,13 +51,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -98,18 +118,18 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
     temperature=0.7,
 )
 
 claude = _orca__block("model", 
-    provider_class=ChatAnthropic,
+    provider="anthropic",
     model_name="claude-sonnet-4-20250514",
     temperature=0,
 )
 
 gemini = _orca__block("model", 
-    provider_class=ChatGoogleGenerativeAI,
+    provider="google",
     model_name="gemini-pro",
 )

--- a/compiler/codegen/testdata/golden/model_no_temperature.py
+++ b/compiler/codegen/testdata/golden/model_no_temperature.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -96,6 +116,6 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 claude = _orca__block("model", 
-    provider_class=ChatAnthropic,
+    provider="anthropic",
     model_name="claude-sonnet-4-20250514",
 )

--- a/compiler/codegen/testdata/golden/multi_agent.py
+++ b/compiler/codegen/testdata/golden/multi_agent.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,12 +117,12 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 
 claude = _orca__block("model", 
-    provider_class=ChatAnthropic,
+    provider="anthropic",
     model_name="claude-sonnet-4-20250514",
     temperature=0.3,
 )

--- a/compiler/codegen/testdata/golden/schema_basic.py
+++ b/compiler/codegen/testdata/golden/schema_basic.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),

--- a/compiler/codegen/testdata/golden/schema_field_desc.py
+++ b/compiler/codegen/testdata/golden/schema_field_desc.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),

--- a/compiler/codegen/testdata/golden/schema_field_multi_ann.py
+++ b/compiler/codegen/testdata/golden/schema_field_multi_ann.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),

--- a/compiler/codegen/testdata/golden/schema_nested.py
+++ b/compiler/codegen/testdata/golden/schema_nested.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),

--- a/compiler/codegen/testdata/golden/schema_pydantic.py
+++ b/compiler/codegen/testdata/golden/schema_pydantic.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -103,7 +123,7 @@ class research_report(BaseModel):
     score: float | None = Field(default=None, description="Confidence score")
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/ternary_expr.py
+++ b/compiler/codegen/testdata/golden/ternary_expr.py
@@ -48,13 +48,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,5 +117,5 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 vars = _orca__block("let", 
     label=("yes" if True else "no"),
     nested=(("a" if False else "b") if True else "c"),
-    with_arith=(3 * 4 if 1 + 2 else 5),
+    with_arith=(12 if 3 else 5),
 )

--- a/compiler/codegen/testdata/golden/workflow_basic.py
+++ b/compiler/codegen/testdata/golden/workflow_basic.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_branch.py
+++ b/compiler/codegen/testdata/golden/workflow_branch.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_branch_chain.py
+++ b/compiler/codegen/testdata/golden/workflow_branch_chain.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_branch_converge.py
+++ b/compiler/codegen/testdata/golden/workflow_branch_converge.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_branch_direct_nested.py
+++ b/compiler/codegen/testdata/golden/workflow_branch_direct_nested.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_branch_nested.py
+++ b/compiler/codegen/testdata/golden/workflow_branch_nested.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_branch_no_transform.py
+++ b/compiler/codegen/testdata/golden/workflow_branch_no_transform.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_branch_standalone.py
+++ b/compiler/codegen/testdata/golden/workflow_branch_standalone.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_cron_webhook.py
+++ b/compiler/codegen/testdata/golden/workflow_cron_webhook.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_diamond.py
+++ b/compiler/codegen/testdata/golden/workflow_diamond.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_empty.py
+++ b/compiler/codegen/testdata/golden/workflow_empty.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -96,6 +116,6 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )

--- a/compiler/codegen/testdata/golden/workflow_fan_out.py
+++ b/compiler/codegen/testdata/golden/workflow_fan_out.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_inline_nodes.py
+++ b/compiler/codegen/testdata/golden/workflow_inline_nodes.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),

--- a/compiler/codegen/testdata/golden/workflow_let_chain.py
+++ b/compiler/codegen/testdata/golden/workflow_let_chain.py
@@ -49,13 +49,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),

--- a/compiler/codegen/testdata/golden/workflow_mixed_nodes.py
+++ b/compiler/codegen/testdata/golden/workflow_mixed_nodes.py
@@ -51,13 +51,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -102,7 +122,7 @@ class report(BaseModel):
     content: str
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_multi_chain.py
+++ b/compiler/codegen/testdata/golden/workflow_multi_chain.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_multi_trigger.py
+++ b/compiler/codegen/testdata/golden/workflow_multi_trigger.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_no_trigger.py
+++ b/compiler/codegen/testdata/golden/workflow_no_trigger.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_single_agent.py
+++ b/compiler/codegen/testdata/golden/workflow_single_agent.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_tool_node.py
+++ b/compiler/codegen/testdata/golden/workflow_tool_node.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_typed_state.py
+++ b/compiler/codegen/testdata/golden/workflow_typed_state.py
@@ -51,13 +51,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -103,7 +123,7 @@ class report(BaseModel):
     score: int = Field(description="Quality score")
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/codegen/testdata/golden/workflow_with_fields.py
+++ b/compiler/codegen/testdata/golden/workflow_with_fields.py
@@ -50,13 +50,33 @@ def _orca__gather(state: dict, predecessors: list[str]) -> Any:
     return {k: state.get(k) for k in predecessors}
 
 
+# FIXME: This is ugly, but works for now, we need to do the provider registry
+# and lookup properly.
+def _orca__provider_from_name(provider: str) -> Any:
+    if provider == "openai":
+        import langchain_openai
+        return langchain_openai.ChatOpenAI
+    elif provider == "anthropic":
+        import langchain_anthropic
+        return langchain_anthropic.ChatAnthropic
+    elif provider == "google":
+        import langchain_google_genai
+        return langchain_google_genai.ChatGoogleGenerativeAI
+    else:
+        raise ValueError(f"Unknown provider: {provider}")
+
+
 def _orca__resolve_model(model_ns: SimpleNamespace) -> Any:
     """Instantiate a LangChain ChatModel from a model SimpleNamespace.
 
     The provider_class field is the actual class (e.g. ChatOpenAI), resolved
     at compile time by the codegen. No runtime provider lookup needed.
     """
-    return model_ns.provider_class(**_orca__fields({
+
+    provider = getattr(model_ns, "provider", "openai")
+    provider_class = _orca__provider_from_name(provider)
+
+    return provider_class(**_orca__fields({
         "model": model_ns.model_name,
         "temperature": getattr(model_ns, "temperature", None),
         "api_key": getattr(model_ns, "api_key", None),
@@ -97,7 +117,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 
 gpt4 = _orca__block("model", 
-    provider_class=ChatOpenAI,
+    provider="openai",
     model_name="gpt-4o",
 )
 

--- a/compiler/go.mod
+++ b/compiler/go.mod
@@ -3,6 +3,7 @@ module github.com/thakee/orca/compiler
 go 1.25.1
 
 require (
+	github.com/fatih/color v1.19.0
 	github.com/spf13/cobra v1.10.2
 	github.com/tliron/commonlog v0.2.21
 	github.com/tliron/glsp v0.2.2
@@ -10,7 +11,6 @@ require (
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/fatih/color v1.19.0 // indirect
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect

--- a/compiler/go.sum
+++ b/compiler/go.sum
@@ -48,8 +48,6 @@ golang.org/x/crypto v0.42.0/go.mod h1:4+rDnOTJhQCx2q7/j6rAN5XDw8kPjeaXEUR2eL94ix
 golang.org/x/net v0.43.0 h1:lat02VYK2j4aLzMzecihNvTlJNQUq316m2Mr9rnM6YE=
 golang.org/x/net v0.43.0/go.mod h1:vhO1fvI4dGsIjh73sWfUVjj3N7CA9WkKJNQm2svM6Jg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
-golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.35.0 h1:bZBVKBudEyhRcajGcNc3jIfWPqV4y/Kt2XcoigOWtDQ=

--- a/compiler/types/constants.go
+++ b/compiler/types/constants.go
@@ -9,6 +9,9 @@ const (
 	BlockKindNumber = "number"
 	BlockKindString = "string"
 
+	BuiltinIdentifierTrue  = "true"
+	BuiltinIdentifierFalse = "false"
+
 	BlockKindLet       = "let"
 	BlockKindWorkflow  = "workflow"
 	BlockKindTool      = "tool"


### PR DESCRIPTION
## Summary
This change hardens compile-time constant folding and keeps LangGraph Python output stable and easier to reason about.

## Details
- **Const folding**: expression results can be cached on the analyzed program, with a sentinel to avoid infinite recursion on cyclic references.
- **Determinism**: map and block-shaped constants no longer use Go `map` iteration for codegen; parallel `keys` / `values` slices preserve insertion order and fix golden flakiness.
- **ConstValue**: carries the originating AST expression, boolean values, and block kind metadata where relevant; folding APIs take `*AnalyzedProgram` for cache and resolution.
- **Codegen**: LangGraph expression emission and provider/runtime wiring updated; all golden `.py` fixtures refreshed.

## Testing
- `cd compiler && go test ./...`

Made with [Cursor](https://cursor.com)