### PR TITLE
Schema types: compiler typing, codegen, docs, editor syntax

### DIFF
--- a/compiler/analyzer/analyzer_test.go
+++ b/compiler/analyzer/analyzer_test.go
@@ -1348,6 +1348,62 @@ func TestAnalyzeWorkflowExpressions(t *testing.T) {
 			"expects type",
 		},
 		{
+			"null instance accepted where nulltype expected in union",
+			`schema S { x = string | nulltype }
+			 S s { x = null }`,
+			false,
+			"",
+		},
+		{
+			"null instance accepted where nulltype expected directly",
+			`schema S { x = nulltype }
+			 S s { x = null }`,
+			false,
+			"",
+		},
+		{
+			"null instance rejected where string expected",
+			`schema S { x = string }
+			 S s { x = null }`,
+			true,
+			"expects type",
+		},
+		{
+			"string accepted in string | nulltype union",
+			`schema S { x = string | nulltype }
+			 S s { x = "hello" }`,
+			false,
+			"",
+		},
+		{
+			"number rejected in string | nulltype union",
+			`schema S { x = string | nulltype }
+			 S s { x = 42 }`,
+			true,
+			"expects type",
+		},
+		{
+			"homogeneous list literal accepted for list[string]",
+			`schema S { tags = list[string] }
+			 S s { tags = ["a", "b", "c"] }`,
+			false,
+			"",
+		},
+		{
+			"heterogeneous list literal falls back to any (permissive)",
+			`schema S { tags = list[string] }
+			 S s { tags = ["a", 1] }`,
+			false,
+			"",
+		},
+		{
+			"list literal element type mismatch",
+			`schema S { tags = list[string] }
+			 S s { tags = [1, 2] }`,
+			true,
+			"expects type",
+		},
+		{
 			"branch route accepts workflow_node block (agent)",
 			`model m { provider = "openai" model_name = "gpt-4o" }
 			 agent a { model = m persona = "You are a helpful assistant." }

--- a/compiler/codegen/python/schema.go
+++ b/compiler/codegen/python/schema.go
@@ -68,7 +68,7 @@ func OrcaTypeToPythonTypeName(t types.Type) string {
 func isOptional(t types.Type) bool {
 	if t.Kind == types.Union {
 		for _, m := range t.Members {
-			if m.IsNull() {
+			if m.IsNullType() {
 				return true
 			}
 		}
@@ -113,15 +113,15 @@ func orcaSchemaToPythonTypeName(t types.Type) string {
 		return "Any"
 	}
 	switch t.BlockName {
-	case "string":
+	case types.BlockKindString:
 		return "str"
-	case "number":
+	case types.BlockKindNumber:
 		return "float"
 	case "bool":
 		return "bool"
-	case "any":
+	case types.BlockKindAny:
 		return "Any"
-	case "null":
+	case types.BlockKindNulltype:
 		return "None"
 	default:
 		// User-defined schema name.

--- a/compiler/codegen/python/schema_test.go
+++ b/compiler/codegen/python/schema_test.go
@@ -21,42 +21,40 @@ func TestOrcaTypeToPythonTypeName(t *testing.T) {
 		expected string
 	}{
 		// Primitives (lazy block refs by name).
-		{"string", lazyRef("string"), "str"},
-		{"int", lazyRef("int"), "int"},
-		{"float", lazyRef("float"), "float"},
+		{"string", lazyRef(types.BlockKindString), "str"},
+		{"number", lazyRef(types.BlockKindNumber), "float"},
 		{"bool", lazyRef("bool"), "bool"},
-		{"any → Any", lazyRef("any"), "Any"},
-		{"null → None", lazyRef("null"), "None"},
+		{"any → Any", lazyRef(types.BlockKindAny), "Any"},
+		{"nulltype → None", lazyRef(types.BlockKindNulltype), "None"},
 
 		// User-defined schema refs.
 		{"user schema", lazyRef("article"), "article"},
 		{"user schema snake_case", lazyRef("vpc_data_t"), "vpc_data_t"},
 
 		// List types.
-		{"list[str]", types.NewListType(lazyRef("string")), "list[str]"},
-		{"list[int]", types.NewListType(lazyRef("int")), "list[int]"},
+		{"list[str]", types.NewListType(lazyRef(types.BlockKindString)), "list[str]"},
+		{"list[float]", types.NewListType(lazyRef(types.BlockKindNumber)), "list[float]"},
 		{"list[article]", types.NewListType(lazyRef("article")), "list[article]"},
-		{"list[list[str]]", types.NewListType(types.NewListType(lazyRef("string"))), "list[list[str]]"},
+		{"list[list[str]]", types.NewListType(types.NewListType(lazyRef(types.BlockKindString))), "list[list[str]]"},
 		{"untyped list", types.Type{Kind: types.List}, "list"},
 
 		// Map types.
-		{"dict[str, int]", types.NewMapType(lazyRef("string"), lazyRef("int")), "dict[str, int]"},
-		{"dict[str, article]", types.NewMapType(lazyRef("string"), lazyRef("article")), "dict[str, article]"},
-		{"dict[str, list[str]]", types.NewMapType(lazyRef("string"), types.NewListType(lazyRef("string"))), "dict[str, list[str]]"},
+		{"dict[str, float]", types.NewMapType(lazyRef(types.BlockKindString), lazyRef(types.BlockKindNumber)), "dict[str, float]"},
+		{"dict[str, article]", types.NewMapType(lazyRef(types.BlockKindString), lazyRef("article")), "dict[str, article]"},
+		{"dict[str, list[str]]", types.NewMapType(lazyRef(types.BlockKindString), types.NewListType(lazyRef(types.BlockKindString))), "dict[str, list[str]]"},
 		{"untyped dict", types.Type{Kind: types.Map}, "dict"},
 
 		// Union types.
-		{"str | None", types.NewUnionType(lazyRef("string"), lazyRef("null")), "str | None"},
-		{"str | int", types.NewUnionType(lazyRef("string"), lazyRef("int")), "str | int"},
-		{"float | None", types.NewUnionType(lazyRef("float"), lazyRef("null")), "float | None"},
-		{"str | int | None", types.NewUnionType(lazyRef("string"), lazyRef("int"), lazyRef("null")), "str | int | None"},
-		{"str | int | float", types.NewUnionType(lazyRef("string"), lazyRef("int"), lazyRef("float")), "str | int | float"},
-		{"list[str] | None", types.NewUnionType(types.NewListType(lazyRef("string")), lazyRef("null")), "list[str] | None"},
-		{"article | None", types.NewUnionType(lazyRef("article"), lazyRef("null")), "article | None"},
+		{"str | None", types.NewUnionType(lazyRef(types.BlockKindString), lazyRef(types.BlockKindNulltype)), "str | None"},
+		{"str | float", types.NewUnionType(lazyRef(types.BlockKindString), lazyRef(types.BlockKindNumber)), "str | float"},
+		{"float | None", types.NewUnionType(lazyRef(types.BlockKindNumber), lazyRef(types.BlockKindNulltype)), "float | None"},
+		{"str | float | None", types.NewUnionType(lazyRef(types.BlockKindString), lazyRef(types.BlockKindNumber), lazyRef(types.BlockKindNulltype)), "str | float | None"},
+		{"list[str] | None", types.NewUnionType(types.NewListType(lazyRef(types.BlockKindString)), lazyRef(types.BlockKindNulltype)), "list[str] | None"},
+		{"article | None", types.NewUnionType(lazyRef("article"), lazyRef(types.BlockKindNulltype)), "article | None"},
 
 		// Unresolved block refs with concrete names pass through as annotations (not empty → Any).
-		{"block name model", lazyRef("model"), "model"},
-		{"block name agent", lazyRef("agent"), "agent"},
+		{"block name model", lazyRef(types.BlockKindModel), "model"},
+		{"block name agent", lazyRef(types.BlockKindAgent), "agent"},
 	}
 
 	for _, tt := range tests {
@@ -87,14 +85,14 @@ func TestSchemaBlockToSource(t *testing.T) {
 					Name: "article",
 					Kind: types.BlockKindSchema,
 					Assignments: []*ast.Assignment{
-						{Name: "title", Value: &ast.Identifier{Value: "string"}},
-						{Name: "count", Value: &ast.Identifier{Value: "int"}},
+						{Name: "title", Value: &ast.Identifier{Value: types.BlockKindString}},
+						{Name: "count", Value: &ast.Identifier{Value: types.BlockKindNumber}},
 					},
 				},
 			},
 			expected: "class article(BaseModel):\n" +
 				"    title: str\n" +
-				"    count: int\n",
+				"    count: float\n",
 		},
 		{
 			name: "all primitive types",
@@ -103,17 +101,15 @@ func TestSchemaBlockToSource(t *testing.T) {
 					Name: "config",
 					Kind: types.BlockKindSchema,
 					Assignments: []*ast.Assignment{
-						{Name: "name", Value: &ast.Identifier{Value: "string"}},
-						{Name: "count", Value: &ast.Identifier{Value: "int"}},
-						{Name: "rate", Value: &ast.Identifier{Value: "float"}},
+						{Name: "name", Value: &ast.Identifier{Value: types.BlockKindString}},
+						{Name: "count", Value: &ast.Identifier{Value: types.BlockKindNumber}},
 						{Name: "enabled", Value: &ast.Identifier{Value: "bool"}},
 					},
 				},
 			},
 			expected: "class config(BaseModel):\n" +
 				"    name: str\n" +
-				"    count: int\n" +
-				"    rate: float\n" +
+				"    count: float\n" +
 				"    enabled: bool\n",
 		},
 		{
@@ -182,7 +178,7 @@ func TestSchemaBlockToSource(t *testing.T) {
 							Value: &ast.BinaryExpression{
 								Left:     &ast.Identifier{Value: "float"},
 								Operator: token.Token{Type: token.PIPE, Literal: "|"},
-								Right:    &ast.Identifier{Value: "null"},
+								Right:    &ast.Identifier{Value: "nulltype"},
 							},
 						},
 					},
@@ -203,7 +199,7 @@ func TestSchemaBlockToSource(t *testing.T) {
 							Value: &ast.BinaryExpression{
 								Left:     &ast.Identifier{Value: "float"},
 								Operator: token.Token{Type: token.PIPE, Literal: "|"},
-								Right:    &ast.Identifier{Value: "null"},
+								Right:    &ast.Identifier{Value: "nulltype"},
 							},
 						},
 					},
@@ -224,7 +220,7 @@ func TestSchemaBlockToSource(t *testing.T) {
 							Value: &ast.BinaryExpression{
 								Left:     &ast.Identifier{Value: "float"},
 								Operator: token.Token{Type: token.PIPE, Literal: "|"},
-								Right:    &ast.Identifier{Value: "null"},
+								Right:    &ast.Identifier{Value: "nulltype"},
 							},
 							Annotations: []*ast.Annotation{
 								{Name: "desc", Arguments: []ast.Expression{&ast.StringLiteral{Value: "Confidence score"}}},
@@ -247,19 +243,19 @@ func TestSchemaBlockToSource(t *testing.T) {
 							Name: "value",
 							Value: &ast.BinaryExpression{
 								Left: &ast.BinaryExpression{
-									Left:     &ast.Identifier{Value: "string"},
+									Left:     &ast.Identifier{Value: types.BlockKindString},
 									Operator: token.Token{Type: token.PIPE, Literal: "|"},
-									Right:    &ast.Identifier{Value: "int"},
+									Right:    &ast.Identifier{Value: types.BlockKindNumber},
 								},
 								Operator: token.Token{Type: token.PIPE, Literal: "|"},
-								Right:    &ast.Identifier{Value: "null"},
+								Right:    &ast.Identifier{Value: types.BlockKindNulltype},
 							},
 						},
 					},
 				},
 			},
 			expected: "class result(BaseModel):\n" +
-				"    value: str | int | None = None\n",
+				"    value: str | float | None = None\n",
 		},
 		{
 			name: "non-optional union",
@@ -271,16 +267,16 @@ func TestSchemaBlockToSource(t *testing.T) {
 						{
 							Name: "value",
 							Value: &ast.BinaryExpression{
-								Left:     &ast.Identifier{Value: "string"},
+								Left:     &ast.Identifier{Value: types.BlockKindString},
 								Operator: token.Token{Type: token.PIPE, Literal: "|"},
-								Right:    &ast.Identifier{Value: "int"},
+								Right:    &ast.Identifier{Value: types.BlockKindNumber},
 							},
 						},
 					},
 				},
 			},
 			expected: "class result(BaseModel):\n" +
-				"    value: str | int\n",
+				"    value: str | float\n",
 		},
 		{
 			name: "nested schema reference",
@@ -310,7 +306,7 @@ func TestSchemaBlockToSource(t *testing.T) {
 							Value: &ast.BinaryExpression{
 								Left:     &ast.Identifier{Value: "address"},
 								Operator: token.Token{Type: token.PIPE, Literal: "|"},
-								Right:    &ast.Identifier{Value: "null"},
+								Right:    &ast.Identifier{Value: "nulltype"},
 							},
 						},
 					},
@@ -395,8 +391,8 @@ func TestSchemaBlockToSource(t *testing.T) {
 								BlockBody: ast.BlockBody{
 									Kind: types.BlockKindSchema,
 									Assignments: []*ast.Assignment{
-										{Name: "text", Value: &ast.Identifier{Value: "string"}},
-										{Name: "score", Value: &ast.Identifier{Value: "int"}},
+										{Name: "text", Value: &ast.Identifier{Value: types.BlockKindString}},
+										{Name: "score", Value: &ast.Identifier{Value: types.BlockKindNumber}},
 									},
 								},
 							},
@@ -458,9 +454,9 @@ func TestSchemaBlockToSource(t *testing.T) {
 						{
 							Name: "rating",
 							Value: &ast.BinaryExpression{
-								Left:     &ast.Identifier{Value: "int"},
+								Left:     &ast.Identifier{Value: types.BlockKindNumber},
 								Operator: token.Token{Type: token.PIPE, Literal: "|"},
-								Right:    &ast.Identifier{Value: "null"},
+								Right:    &ast.Identifier{Value: types.BlockKindNulltype},
 							},
 							Annotations: []*ast.Annotation{
 								{Name: "desc", Arguments: []ast.Expression{&ast.StringLiteral{Value: "Optional rating"}}},
@@ -479,7 +475,7 @@ func TestSchemaBlockToSource(t *testing.T) {
 			expected: "class report(BaseModel):\n" +
 				"    title: str = Field(description=\"Report title\")\n" +
 				"    body: str\n" +
-				"    rating: int | None = Field(default=None, description=\"Optional rating\")\n" +
+				"    rating: float | None = Field(default=None, description=\"Optional rating\")\n" +
 				"    tags: list[str]\n",
 		},
 		{
@@ -494,15 +490,15 @@ func TestSchemaBlockToSource(t *testing.T) {
 							Value: &ast.BinaryExpression{
 								Left:     &ast.Identifier{Value: "string"},
 								Operator: token.Token{Type: token.PIPE, Literal: "|"},
-								Right:    &ast.Identifier{Value: "null"},
+								Right:    &ast.Identifier{Value: "nulltype"},
 							},
 						},
 						{
 							Name: "b",
 							Value: &ast.BinaryExpression{
-								Left:     &ast.Identifier{Value: "int"},
+								Left:     &ast.Identifier{Value: types.BlockKindNumber},
 								Operator: token.Token{Type: token.PIPE, Literal: "|"},
-								Right:    &ast.Identifier{Value: "null"},
+								Right:    &ast.Identifier{Value: types.BlockKindNulltype},
 							},
 						},
 					},
@@ -510,7 +506,7 @@ func TestSchemaBlockToSource(t *testing.T) {
 			},
 			expected: "class opts(BaseModel):\n" +
 				"    a: str | None = None\n" +
-				"    b: int | None = None\n",
+				"    b: float | None = None\n",
 		},
 	}
 

--- a/compiler/codegen/testdata/golden/schema_basic.orca
+++ b/compiler/codegen/testdata/golden/schema_basic.orca
@@ -1,4 +1,4 @@
 schema vpc_data_t {
   region         = string
-  instance_count = int
+  instance_count = number
 }

--- a/compiler/codegen/testdata/golden/schema_basic.py
+++ b/compiler/codegen/testdata/golden/schema_basic.py
@@ -118,4 +118,4 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 class vpc_data_t(BaseModel):
     region: str
-    instance_count: int
+    instance_count: float

--- a/compiler/codegen/testdata/golden/schema_pydantic.orca
+++ b/compiler/codegen/testdata/golden/schema_pydantic.orca
@@ -4,7 +4,7 @@ schema research_report {
   @desc("Key findings from research")
   findings = list[string]
   @desc("Confidence score")
-  score    = float | null
+  score    = number | nulltype
 }
 
 agent researcher {

--- a/compiler/codegen/testdata/golden/workflow_typed_state.orca
+++ b/compiler/codegen/testdata/golden/workflow_typed_state.orca
@@ -2,7 +2,7 @@ schema report {
   @desc("The report content")
   content = string
   @desc("Quality score")
-  score   = int
+  score   = number
 }
 
 model gpt4 {

--- a/compiler/codegen/testdata/golden/workflow_typed_state.py
+++ b/compiler/codegen/testdata/golden/workflow_typed_state.py
@@ -120,7 +120,7 @@ def _orca__invoke_tool(tool: SimpleNamespace, input_data: Any) -> Any:
 
 class report(BaseModel):
     content: str = Field(description="The report content")
-    score: int = Field(description="Quality score")
+    score: float = Field(description="Quality score")
 
 gpt4 = _orca__block("model", 
     provider="openai",

--- a/compiler/types/bootstrap.orca
+++ b/compiler/types/bootstrap.orca
@@ -16,6 +16,13 @@ schema schema {}
 
 @suppress("duplicate-block")
 @strict_check
+schema nulltype {}
+
+@suppress("duplicate-block")
+nulltype null {}
+
+@suppress("duplicate-block")
+@strict_check
 schema bool {}
 
 @suppress("duplicate-block")
@@ -54,16 +61,12 @@ schema any {}
 
 @suppress("duplicate-block")
 @strict_check
-schema null {}
-
-@suppress("duplicate-block")
-@strict_check
 schema workflow {
   @desc("The name of the workflow.")
-  name = string | null
+  name = string | nulltype
 
   @desc("The description of the workflow.")
-  desc = string | null
+  desc = string | nulltype
 }
 
 @suppress("duplicate-block")
@@ -76,13 +79,13 @@ schema model {
   model_name = string
 
   @desc("The API key to use for this model.")
-  api_key = string | null
+  api_key = string | nulltype
 
   @desc("The base URL to use for this model.")
-  base_url = string | null
+  base_url = string | nulltype
 
   @desc("Sampling temperature between 0 and 1.")
-  temperature = number | null
+  temperature = number | nulltype
 }
 
 @suppress("duplicate-block")
@@ -90,13 +93,13 @@ schema model {
 @workflow_node
 schema tool {
   @desc("The description of the tool.")
-  desc = string | null
+  desc = string | nulltype
 
   @desc("The input schema for the tool.")
-  input_schema = schema | null
+  input_schema = schema | nulltype
 
   @desc("The output schema for the tool.")
-  output_schema = schema | null
+  output_schema = schema | nulltype
 
   @desc("The callable to invoke for the tool.")
   invoke = callable
@@ -113,13 +116,13 @@ schema agent {
   persona = string
 
   @desc("The tools to use for this agent.")
-  tools = list[tool] | null
+  tools = list[tool] | nulltype
 
   @desc("Whether to use thinking tokens for the agent.")
-  thinking = bool | null
+  thinking = bool | nulltype
 
   @desc("The structured output schema for this agent.")
-  output_schema = schema | null
+  output_schema = schema | nulltype
 }
 
 @suppress("duplicate-block")
@@ -131,7 +134,7 @@ schema cron {
   schedule = string
 
   @desc("IANA timezone name (e.g. \"America/New_York\"). Defaults to UTC when unset.")
-  timezone = string | null
+  timezone = string | nulltype
 }
 
 @suppress("duplicate-block")
@@ -143,7 +146,7 @@ schema webhook {
   path = string
 
   @desc("HTTP method (e.g. \"POST\").")
-  method = string | null
+  method = string | nulltype
 }
 
 
@@ -165,7 +168,7 @@ schema branch {
     }
   }
   ```)
-  transform = callable | null
+  transform = callable | nulltype
 
   @desc("The routes to take based on the input.")
   route = map[string | number | bool, annotated["workflow_node"]]

--- a/compiler/types/bootstrap_test.go
+++ b/compiler/types/bootstrap_test.go
@@ -79,15 +79,15 @@ func TestLoadSchemasFieldTypes(t *testing.T) {
 		required bool
 		wantStr  string
 	}{
-		{"agent.tools", "agent", "tools", Union, false, "list[tool] | null"},
+		{"agent.tools", "agent", "tools", Union, false, "list[tool] | nulltype"},
 		{"model.model_name", "model", "model_name", BlockRef, true, "string"},
 		{"agent.model", "agent", "model", Union, true, "string | model"},
 		{"model.provider", "model", "provider", BlockRef, true, "string"},
-		{"model.temperature", "model", "temperature", Union, false, "number | null"},
+		{"model.temperature", "model", "temperature", Union, false, "number | nulltype"},
 		{"agent.persona", "agent", "persona", BlockRef, true, "string"},
-		{"tool.desc", "tool", "desc", Union, false, "string | null"},
+		{"tool.desc", "tool", "desc", Union, false, "string | nulltype"},
 		{"tool.invoke", "tool", "invoke", BlockRef, true, "callable"},
-		{"workflow.name", "workflow", "name", Union, false, "string | null"},
+		{"workflow.name", "workflow", "name", Union, false, "string | nulltype"},
 	}
 
 	for _, tt := range tests {
@@ -326,14 +326,14 @@ func TestFieldSchemaOptionalNullInUnion(t *testing.T) {
 		memberCount int
 	}{
 		{
-			"string | null optional, union retains null",
-			"schema test_strip {\n  @suppress(\"duplicate-block\")\n  field = string | null\n}",
-			false, Union, "string | null", 2,
+			"string | nulltype optional, union retains null",
+			"schema test_strip {\n  @suppress(\"duplicate-block\")\n  field = string | nulltype\n}",
+			false, Union, "string | nulltype", 2,
 		},
 		{
-			"string | model | null optional, full union",
-			"schema test_strip2 {\n  @suppress(\"duplicate-block\")\n  field = string | model | null\n}",
-			false, Union, "string | model | null", 3,
+			"string | model | nulltype optional, full union",
+			"schema test_strip2 {\n  @suppress(\"duplicate-block\")\n  field = string | model | nulltype\n}",
+			false, Union, "string | model | nulltype", 3,
 		},
 		{
 			"string (no union) is required BlockRef",

--- a/compiler/types/constants.go
+++ b/compiler/types/constants.go
@@ -6,6 +6,7 @@ const (
 
 	BlockKindAny       = "any"
 	BlockKindNull      = "null"
+	BlockKindNulltype  = "nulltype"
 	BlockKindNumber    = "number"
 	BlockKindString    = "string"
 	BlockKindList      = "list"

--- a/compiler/types/expr_type.go
+++ b/compiler/types/expr_type.go
@@ -500,25 +500,23 @@ func mapLiteralType(depth int, m *ast.MapLiteral, symtab *SymbolTable) Type {
 	return NewMapType(keyT, valT)
 }
 
-// listLiteralType infers the type of a list literal. If all elements
-// have the same type, returns list[T]. Otherwise returns an untyped list.
+// listLiteralType infers the type of a list literal by unifying element
+// types at the caller's depth. If every element's type equals the first
+// element's type, that becomes the list element type; otherwise the
+// element type falls back to any — matching mapLiteralType's approach.
 func listLiteralType(depth int, list *ast.ListLiteral, symbols *SymbolTable) Type {
 	if len(list.Elements) == 0 {
 		return Type{Kind: List}
 	}
 
-	// TODO: depth, symbols is not used here but it should be.
-
-	// TODO: Check if the first element's type is compatible with
-	// first := ExprType(list.Elements[0], symbols)
-	// for _, elem := range list.Elements[1:] {
-	// 	if !ExprType(elem, symbols).Equals(first) {
-	// 		return Type{Kind: List}
-	// 	}
-	// }
-	// return NewListType(first)
-
-	return Type{Kind: List}
+	elemT := schemaFromExprWithDepth(depth, list.Elements[0], symbols)
+	for _, elem := range list.Elements[1:] {
+		if t := schemaFromExprWithDepth(depth, elem, symbols); !t.Equals(elemT) {
+			elemT = anyType(symbols)
+			break
+		}
+	}
+	return NewListType(elemT)
 }
 
 func anyType(symtab *SymbolTable) Type {

--- a/compiler/types/expr_type_test.go
+++ b/compiler/types/expr_type_test.go
@@ -38,11 +38,19 @@ func TestExprTypeFromExpr(t *testing.T) {
 // TestExprTypeFromExprList verifies list literal type inference.
 func TestExprTypeFromExprList(t *testing.T) {
 	st := bootstrapSymtab(t)
+	stringT := IdentType(0, BlockKindString, st)
+	anyT := IdentType(0, BlockKindAny, st)
+
+	// Empty list: no element type.
 	got := EvalType(&ast.ListLiteral{}, st)
 	if got.Kind != List {
 		t.Fatalf("Kind = %v, want List", got.Kind)
 	}
+	if got.ElementType != nil {
+		t.Error("empty list ElementType should be nil")
+	}
 
+	// Homogeneous list: element type inferred from entries.
 	list := &ast.ListLiteral{
 		Elements: []ast.Expression{
 			&ast.StringLiteral{Value: "a"},
@@ -53,8 +61,20 @@ func TestExprTypeFromExprList(t *testing.T) {
 	if got.Kind != List {
 		t.Fatalf("Kind = %v, want List", got.Kind)
 	}
-	if got.ElementType != nil {
-		t.Fatal("ElementType should be nil until list[T] inference is implemented")
+	if got.ElementType == nil || !got.ElementType.Equals(stringT) {
+		t.Errorf("homogeneous ElementType = %v, want %s", got.ElementType, stringT.String())
+	}
+
+	// Heterogeneous list: element type falls back to any.
+	mixed := &ast.ListLiteral{
+		Elements: []ast.Expression{
+			&ast.StringLiteral{Value: "a"},
+			&ast.NumberLiteral{Value: 1},
+		},
+	}
+	got = EvalType(mixed, st)
+	if got.ElementType == nil || !got.ElementType.Equals(anyT) {
+		t.Errorf("heterogeneous ElementType = %v, want %s", got.ElementType, anyT.String())
 	}
 }
 
@@ -240,22 +260,22 @@ func TestExprTypeFromExprSubscription(t *testing.T) {
 		expected Type
 	}{
 		{
-			"list[str] subscript returns any (untyped list)",
+			"list[string] subscript returns string",
 			&ast.ListLiteral{Elements: []ast.Expression{
 				&ast.StringLiteral{Value: "a"},
 				&ast.StringLiteral{Value: "b"},
 			}},
 			&ast.NumberLiteral{Value: 0},
-			anyTyp,
+			IdentType(0, BlockKindString, st),
 		},
 		{
-			"list[number] subscript returns any (untyped list)",
+			"list[number] subscript returns number",
 			&ast.ListLiteral{Elements: []ast.Expression{
 				&ast.NumberLiteral{Value: 1},
 				&ast.NumberLiteral{Value: 2},
 			}},
 			&ast.NumberLiteral{Value: 0},
-			anyTyp,
+			IdentType(0, BlockKindNumber, st),
 		},
 		{
 			"map[string, string] subscript returns string",

--- a/compiler/types/schema.go
+++ b/compiler/types/schema.go
@@ -70,7 +70,7 @@ func newFieldSchema(assign *ast.Assignment, typ Type) FieldSchema {
 	// A union containing null makes the field optional.
 	if typ.Kind == Union {
 		for _, m := range typ.Members {
-			if m.IsNull() {
+			if m.IsNullType() {
 				fs.Required = false
 			}
 		}

--- a/compiler/types/schema_test.go
+++ b/compiler/types/schema_test.go
@@ -345,10 +345,10 @@ func TestGetFieldSchema(t *testing.T) {
 	}{
 		{"model provider", "model", "provider", true, BlockRef, "string", true},
 		{"model model_name", "model", "model_name", true, BlockRef, "string", true},
-		{"model temperature", "model", "temperature", true, Union, "number | null", false},
+		{"model temperature", "model", "temperature", true, Union, "number | nulltype", false},
 		{"agent model union", "agent", "model", true, Union, "string | model", true},
 		{"agent persona", "agent", "persona", true, BlockRef, "string", true},
-		{"agent tools list", "agent", "tools", true, Union, "list[tool] | null", false},
+		{"agent tools list", "agent", "tools", true, Union, "list[tool] | nulltype", false},
 		{"unknown field", "model", "nonexistent", false, BlockRef, "", false},
 	}
 

--- a/compiler/types/types.go
+++ b/compiler/types/types.go
@@ -126,29 +126,29 @@ func NewBlockRefType(blockName string, block *BlockSchema) Type {
 	return Type{Kind: BlockRef, BlockName: blockName, Block: block}
 }
 
+func isTypeNamed(t Type, name string) bool {
+	if t.Kind != BlockRef {
+		return false
+	}
+	if t.Block != nil {
+		return t.Block.BlockName == name
+	}
+	return t.BlockName == name
+}
+
 // FIXME: I dont like null/any being some special thing and hardcoded, fix it.
 // IsAny returns true if this type is the "any" type (matches everything).
 func (t Type) IsAny() bool {
-	if t.Kind != BlockRef {
-		return false
-	}
-	if t.Block != nil {
-		return t.Block.BlockName == "any"
-	}
-	// Unresolved identifier "any" (bootstrap / before schema resolution).
-	return t.BlockName == "any"
+	return isTypeNamed(t, BlockKindAny)
 }
 
 // IsNull returns true if this type is the "null" type.
-func (t Type) IsNull() bool {
-	if t.Kind != BlockRef {
-		return false
-	}
-	if t.Block != nil {
-		return t.Block.BlockName == "null"
-	}
-	// Unresolved identifier "null" so newFieldSchema can strip `| null` from unions.
-	return t.BlockName == "null"
+func (t Type) IsNullType() bool {
+	return isTypeNamed(t, BlockKindNulltype)
+}
+
+func (t Type) IsNullInst() bool {
+	return isTypeNamed(t, BlockKindNull)
 }
 
 // String returns a human-readable representation of a type using Orca syntax.

--- a/compiler/types/types_test.go
+++ b/compiler/types/types_test.go
@@ -265,13 +265,13 @@ func TestIsAny(t *testing.T) {
 
 // TestIsNull verifies the IsNull helper.
 func TestIsNull(t *testing.T) {
-	if !nullResolved().IsNull() {
+	if !nullResolved().IsNullInst() {
 		t.Error("resolved null.IsNull() should be true")
 	}
-	if !ident("null").IsNull() {
+	if !ident("null").IsNullInst() {
 		t.Error("lazy null identifier.IsNull() should be true")
 	}
-	if ident("string").IsNull() {
+	if ident("string").IsNullInst() {
 		t.Error("lazy str.IsNull() should be false")
 	}
 }

--- a/docs/reference/agent.md
+++ b/docs/reference/agent.md
@@ -19,8 +19,8 @@ agent <name> {
 |-------|------|----------|-------------|
 | `model` | `string \| model` | Yes | Reference to a model block or a model string |
 | `persona` | `string` | Yes | The agent's system prompt / behavior description |
-| `tools` | `list[tool] \| null` | No | List of tool references the agent can use |
-| `output_schema` | `schema \| null` | No | Structured output schema for the agent's response |
+| `tools` | `list[tool] \| nulltype` | No | List of tool references the agent can use |
+| `output_schema` | `schema \| nulltype` | No | Structured output schema for the agent's response |
 
 ## Examples
 

--- a/docs/reference/cron.md
+++ b/docs/reference/cron.md
@@ -16,7 +16,7 @@ cron <name> {
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `schedule` | `string` | Yes | Cron expression (e.g. `"0 9 * * 1-5"`) |
-| `timezone` | `string \| null` | No | IANA timezone (e.g. `"America/New_York"`). Defaults to UTC when unset |
+| `timezone` | `string \| nulltype` | No | IANA timezone (e.g. `"America/New_York"`). Defaults to UTC when unset |
 
 ## Workflow usage
 

--- a/docs/reference/input.md
+++ b/docs/reference/input.md
@@ -18,9 +18,9 @@ input <name> {
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `type` | `schema` | Yes | The type of the input (primitive, schema reference, or inline schema) |
-| `desc` | `string \| null` | No | Description of the input |
-| `default` | `any \| null` | No | Default value if not provided at runtime |
-| `sensitive` | `bool \| null` | No | Whether this input contains sensitive data (e.g., API keys) |
+| `desc` | `string \| nulltype` | No | Description of the input |
+| `default` | `any \| nulltype` | No | Default value if not provided at runtime |
+| `sensitive` | `bool \| nulltype` | No | Whether this input contains sensitive data (e.g., API keys) |
 
 ## Examples
 
@@ -54,8 +54,8 @@ input network {
 input config {
   type = schema {
     region   = string
-    replicas = int
-    debug    = bool | null
+    replicas = number
+    debug    = bool | nulltype
   }
   desc = "Runtime configuration"
 }

--- a/docs/reference/model.md
+++ b/docs/reference/model.md
@@ -10,7 +10,7 @@ model <name> {
   model_name  = <string>
   api_key     = <string>  // optional
   base_url    = <string>  // optional
-  temperature = <float>   // optional
+  temperature = <number>  // optional
 }
 ```
 
@@ -20,9 +20,9 @@ model <name> {
 |-------|------|----------|-------------|
 | `provider` | `string` | Yes | LLM provider: `"openai"`, `"anthropic"`, or `"google"` |
 | `model_name` | `string \| model` | Yes | The model identifier (e.g., `"gpt-4o"`, `"claude-sonnet"`) |
-| `api_key` | `string \| null` | No | API key for the provider (overrides environment variable) |
-| `base_url` | `string \| null` | No | Custom base URL for the provider endpoint |
-| `temperature` | `float \| null` | No | Sampling temperature (0.0 – 1.0) |
+| `api_key` | `string \| nulltype` | No | API key for the provider (overrides environment variable) |
+| `base_url` | `string \| nulltype` | No | Custom base URL for the provider endpoint |
+| `temperature` | `number \| nulltype` | No | Sampling temperature (0.0 – 1.0) |
 
 ## Supported providers
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -13,14 +13,14 @@ schema <name> {
 
 ## Field types
 
-Each field is assigned a type. Use `| null` to make a field optional:
+Each field is assigned a type. Use `| nulltype` to make a field optional — `nulltype` is the type whose only value is `null`:
 
 ```orca
 schema report {
-  title    = string           // required
-  summary  = string           // required
-  sources  = list[string]     // required
-  word_count = int | null  // optional
+  title      = string                // required
+  summary    = string                // required
+  sources    = list[string]          // required
+  word_count = number | nulltype     // optional
 }
 ```
 
@@ -48,7 +48,7 @@ schema report {
 ```orca
 schema analysis {
   sentiment  = string
-  confidence = float
+  confidence = number
   keywords   = list[string]
 }
 

--- a/docs/reference/syntax-overview.md
+++ b/docs/reference/syntax-overview.md
@@ -31,11 +31,12 @@ model gpt4 {
 | Type | Description |
 |------|-------------|
 | `string` | String |
-| `int` | Integer |
-| `float` | Floating-point number |
+| `number` | Numeric value (integer or floating-point) |
 | `bool` | Boolean (`true` / `false`) |
-| `null` | Null value |
+| `nulltype` | The type whose sole instance is `null` |
 | `any` | Matches any type |
+
+`nulltype` is the *type*; `null` is its singleton *value*. Use `nulltype` in type positions (field declarations, unions) and `null` in value positions (assignments).
 
 ### Collections
 
@@ -59,11 +60,48 @@ headers = {
 Use the pipe operator `|` to allow multiple types:
 
 ```orca
-model_name = stringing | model    // accepts a string or a model reference
-temperature = float | null  // optional field (null means it can be omitted)
+model_name  = string | model      // accepts a string or a model reference
+temperature = number | nulltype   // optional field (null means it can be omitted)
 ```
 
-A field with `| null` in its type is optional.
+A field with `| nulltype` in its type is optional — the field may either hold a value of the other arm or the singleton `null`.
+
+### Structural (duck) typing
+
+Two schemas are compatible when the providing schema has every required field declared in the expected schema, with matching types. Extra fields are ignored.
+
+```orca
+schema quackable { quack = string }
+schema duck      { quack = string }   // extra fields allowed
+
+duck mike { quack = "quack mike quack" }
+
+schema S { x = quackable }
+S s { x = mike }                      // ok — `duck` implements `quackable`
+```
+
+Add `@strict_check` to a schema to require a nominal match instead — only blocks whose schema is exactly that schema (or an instance of it) are accepted:
+
+```orca
+@strict_check
+schema quackable { quack = string }
+
+S s { x = mike }                      // error: duck is not quackable
+```
+
+Primitive schemas (`string`, `number`, `bool`, `nulltype`, `list`, `map`, `callable`, `any`, `schema`) are declared with `@strict_check` so unrelated primitives don't match each other structurally.
+
+### Annotated types
+
+Use `annotated["<name>"]` in a type position to accept any block whose schema carries the `@<name>` annotation. This is how `branch.route` and `workflow_chain.left`/`right` declare "any workflow-node-like block":
+
+```orca
+schema branch {
+  route = map[string | number | bool, annotated["workflow_node"]]
+}
+```
+
+A block is compatible with `annotated["foo"]` when its defining schema carries `@foo`. Annotated types are nominal: only the annotation name is checked, not the fields.
 
 ### References
 
@@ -105,10 +143,10 @@ first_tool = my_tools[0]
 
 ```orca
 name     = "hello"       // string
-count    = 42            // integer
-rate     = 0.7           // float
-enabled  = true          // boolean
-nothing  = null          // null
+count    = 42            // number (integer)
+rate     = 0.7           // number (float)
+enabled  = true          // bool
+nothing  = null          // nulltype (the singleton null value)
 ```
 
 ### Arithmetic
@@ -255,7 +293,7 @@ schema report {
   title = string
 
   @desc("Word count limit")
-  max_words = int | null
+  max_words = number | nulltype
 }
 ```
 

--- a/docs/reference/tool.md
+++ b/docs/reference/tool.md
@@ -18,9 +18,9 @@ tool <name> {
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | `string` | Yes | The tool's identifier |
-| `desc` | `string \| null` | No | A description of what the tool does |
-| `input_schema` | `schema \| null` | No | Schema describing the tool's input parameters |
-| `invoke` | `string \| null` | No | Fully-qualified Python function to call when the tool is invoked |
+| `desc` | `string \| nulltype` | No | A description of what the tool does |
+| `input_schema` | `schema \| nulltype` | No | Schema describing the tool's input parameters |
+| `invoke` | `string \| nulltype` | No | Fully-qualified Python function to call when the tool is invoked |
 
 ## Examples
 
@@ -48,7 +48,7 @@ tool slack {
 ```orca
 schema search_input {
   query   = string
-  max_results = int | null
+  max_results = number | nulltype
 }
 
 tool search {

--- a/docs/reference/webhook.md
+++ b/docs/reference/webhook.md
@@ -16,7 +16,7 @@ webhook <name> {
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `path` | `string` | Yes | URL path (e.g. `"/hooks/job"`) |
-| `method` | `string \| null` | No | HTTP method (e.g. `"POST"`). Omitted in generated code when unset |
+| `method` | `string \| nulltype` | No | HTTP method (e.g. `"POST"`). Omitted in generated code when unset |
 
 ## Workflow usage
 

--- a/docs/reference/workflow.md
+++ b/docs/reference/workflow.md
@@ -16,8 +16,8 @@ workflow <name> {
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `name` | `string \| null` | No | Display name for the workflow |
-| `desc` | `string \| null` | No | A description of what the workflow does |
+| `name` | `string \| nulltype` | No | Display name for the workflow |
+| `desc` | `string \| nulltype` | No | A description of what the workflow does |
 
 ## Arrow syntax
 

--- a/editor/vscode/syntaxes/orca.tmLanguage.json
+++ b/editor/vscode/syntaxes/orca.tmLanguage.json
@@ -203,11 +203,11 @@
     "keyword": {
       "patterns": [
         {
-          "match": "\\b(string|number|nul|null|bool|list|map|any|true|false|callable|annotated)\\b",
+          "match": "\\b(string|number|nulltype|null|bool|list|map|any|true|false|callable|annotated)\\b",
           "name": "keyword.language.primitive.orca"
         },
         {
-          "match": "\\b(schema|model|agent|workflow)\\b",
+          "match": "\\b(schema|tool|model|agent|workflow|cron|webhook|branch)\\b",
           "name": "keyword.other.block-type.orca"
         }
       ]


### PR DESCRIPTION
## Summary

- Tightens Orca **schema / map typing** in the type checker (`compiler/types`), including bootstrap definitions and expression typing updates.
- Adjusts **Python schema codegen** and golden fixtures; extends **analyzer** coverage.
- Refreshes **reference docs** (schema, syntax overview, block pages) to match current language behavior.
- Tweaks **VS Code** Orca grammar for new or updated syntax.

## Testing

- `cd compiler && go test ./...`


Made with [Cursor](https://cursor.com)