### PR TITLE
📝 docs: use triple-backtick multiline persona in examples

### DIFF
--- a/docs/examples/multi-agent-workflow.md
+++ b/docs/examples/multi-agent-workflow.md
@@ -22,7 +22,7 @@ model claude {
 
 ### `agents.orca`
 
-```orca
+~~~orca
 tool search {
   desc   = "Search the web for information"
   invoke = "tools.search.web_search"
@@ -30,32 +30,32 @@ tool search {
 
 agent researcher {
   model   = gpt4
-  persona = "
+  persona = ```md
     You are a research specialist.
     You search for information and compile
     detailed findings with sources.
-    "
+    ```
   tools   = [search]
 }
 
 agent writer {
   model   = claude
-  persona = "
+  persona = ```md
     You are a technical writer.
     You take research findings and turn them
     into clear, well-structured articles.
-    "
+    ```
 }
 
 agent editor {
   model   = gpt4
-  persona = "
+  persona = ```md
     You are an editor.
     You review articles for clarity, accuracy,
     and grammar. You suggest improvements.
-    "
+    ```
 }
-```
+~~~
 
 ### `workflow.orca`
 

--- a/docs/examples/simple-agent.md
+++ b/docs/examples/simple-agent.md
@@ -4,7 +4,7 @@ A minimal Orca project with one model, one tool, and one agent.
 
 ## Source (`main.orca`)
 
-```orca
+~~~orca
 model gpt4 {
   provider    = "openai"
   model_name  = "gpt-4o"
@@ -18,16 +18,16 @@ tool search {
 
 agent researcher {
   model   = gpt4
-  persona = "
+  persona = ```md
     You are a research assistant.
     You search the web for information and
     provide well-sourced answers.
 
     Always cite your sources.
-    "
+    ```
   tools   = [search]
 }
-```
+~~~
 
 ## Build
 


### PR DESCRIPTION
## Summary
- update docs/examples/simple-agent.md to use triple-backtick multiline persona syntax
- update docs/examples/multi-agent-workflow.md to use triple-backtick multiline persona syntax
- switch outer markdown code fences in those snippets to tildes so inner triple backticks render correctly

## Validation
- pnpm run build (docs)